### PR TITLE
[Do not merge] experimental bucklescript support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /_opam/
 /*.install
 .merlin
+node_modules
+lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ jobs:
   include:
     - stage: bucklescript
       language: node_js
+      node_js:
+        - 12
       script: npm install && npm run build
 
 # The default 'test' job

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,29 @@
+stages:
+  - test # actually, this is the "build" stage
+         # (defined in the job matrix ("env.matrix" and "script" root node)
+         # https://docs.travis-ci.com/user/build-stages/#specifying-stage-order-and-conditions)
+  - bucklescript
+
+# This creates the bucklescript stage, which only runs the bucklescript build. The relevant travis
+# feature is "Build stages" (https://docs.travis-ci.com/user/build-stages/).
+# Unfortunately it doesn't support matrix expansion, so we define the build
+# stage the "old-fashioned" way down below this section.
+jobs:
+  include:
+    - stage: bucklescript
+      language: node_js
+      script: npm && npm run build
+
+# The default 'test' job
 language: c
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
-script: bash -ex .travis-docker.sh
 sudo: required
 services:
   - docker
 sudo: false
 dist: bionic
+
+script: bash -ex .travis-docker.sh
 env:
   global:
   - DEPOPTS="*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
   include:
     - stage: bucklescript
       language: node_js
-      script: npm && npm run build
+      script: npm install && npm run build
 
 # The default 'test' job
 language: c

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,0 +1,15 @@
+{
+  "name": "ocaml-protoc-plugin-runtime-bs",
+  "namespace": "Protobuf",
+  "refmt": 3,
+  "sources": [
+    {
+      "dir": "src/protobuf"
+    }
+  ],
+  "package-specs": {
+    "module": "commonjs",
+    "in-source": true
+  },
+  "suffix": ".bs.js"
+}

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -8,8 +8,7 @@
     }
   ],
   "package-specs": {
-    "module": "commonjs",
-    "in-source": true
+    "module": "commonjs"
   },
   "suffix": ".bs.js"
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "bs-platform": "6.0.1"
   },
   "scripts": {
-    "build": "bsb -make-world",
-    "clean": "bsb -clean-world"
+    "build": "bsb -clean-world -make-world"
   },
   "keywords": [
     "reasonml",

--- a/package.json
+++ b/package.json
@@ -17,5 +17,9 @@
     "protobuf",
     "protoc"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "files": [
+    "./bsconfig.json",
+    "./src/protobuf"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ocaml-protoc-plugin-runtime-bs",
+  "version": "0.0.1",
+  "description": "BuckleScript runtime for ocaml-protoc-plugin",
+  "peerDependencies": {
+    "bs-platform": ">=5.0.0"
+  },
+  "devDependencies": {
+    "bs-platform": "6.0.1"
+  },
+  "scripts": {
+    "build": "bsb -make-world",
+    "clean": "bsb -clean-world"
+  },
+  "keywords": [
+    "reasonml",
+    "bucklescript",
+    "protobuf",
+    "protoc"
+  ],
+  "license": "MIT"
+}

--- a/package.json
+++ b/package.json
@@ -18,5 +18,5 @@
     "protobuf",
     "protoc"
   ],
-  "license": "MIT"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
This PR adds... and removes what's needed for BuckleScript support. 

I removed inline tests. There's no inline test ppx distribution built for OCaml. The problem with bundling your own is that there are two versions of bucklescript in the wild and since there's no native build system typically involved, packages tend to distribute prebuilt ppx binaries for different platforms. Oh, and did I mention you need to use non-driver based ppxes?

Therefore, I don't know what's the solution here. I realise this is a native-first (or dune first) project so I don't want to impose any "solutions" on you. 

Besides, I added package.json (metadata for npm - JavaScript package registry) and bsconfig.json (config file for BuckleScript.)

What's missing from here is a step on Travis which would just run a bucklescript build. It takes very little time - bucklescript compiler is distributed as a binary, so installing it and running the build should be just a few seconds.