### PR TITLE
Added dev dependencies to conf-protoc package

### DIFF
--- a/conf-protoc.opam
+++ b/conf-protoc.opam
@@ -8,17 +8,17 @@ dev-repo: "git+https://github.com/protocolbuffers/protobuf.git"
 build: [ "protoc" "--version" ]
 
 depexts: [
-  ["protobuf-compiler"] {os-distribution = "debian"}
-  ["protobuf-compiler"] {os-distribution = "mageia"}
-  ["protobuf-compiler"] {os-distribution = "ubuntu"}
-  ["protobuf-compiler"] {os-distribution = "centos"}
-  ["protobuf-compiler"] {os-distribution = "fedora"}
-  ["protobuf-compiler"] {os-distribution = "rhel"}
-  ["protobuf"]          {os-distribution = "alpine"}
-  ["protobuf"]          {os-distribution = "arch"}
-  ["protobuf-devel"]    {os-family = "suse"}
-  ["protobuf"]          {os = "freebsd"}
-  ["protobuf"]          {os = "macos" & os-distribution = "homebrew"}
+  ["libprotobuf-dev" "protobuf-compiler"]   {os-distribution = "debian"}
+  ["libprotobuf-devel" "protobuf-compiler"] {os-distribution = "mageia"}
+  ["libprotobuf-dev" "protobuf-compiler"]   {os-distribution = "ubuntu"}
+  ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "centos"}
+  ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "fedora"}
+  ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "rhel"}
+  ["protobuf"]                              {os-distribution = "alpine"}
+  ["protobuf"]                              {os-distribution = "arch"}
+  ["protobuf-devel"]                        {os-family = "suse"}
+  ["protobuf"]                              {os = "freebsd"}
+  ["protobuf"]                              {os = "macos" & os-distribution = "homebrew"}
 ]
 
 available: os-distribution != "ubuntu" | os-version >= "18.04"


### PR DESCRIPTION
This adds dependencies to `conf-protoc` in order to ensure that Google's common `.proto` files get installed as well.