### PR TITLE
Update bsconfig and package.json for 3.0.0

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,42 @@
+name: Publish packages to npm
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+          ref: ${{ github.ref }}
+          submodules: true
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - name: Publish packages
+        run: |
+          set -e
+          extract() {
+            # Field's key/value should be on their own line
+            echo $(cat package.json \
+              | grep "$1" \
+              | head -1 \
+              | awk -F: '{ print $2 }' \
+              | sed 's/[",]//g')
+          }
+
+          PACKAGE_NAME=$(extract name)
+          PACKAGE_VERSION=$(extract version)
+          NPM_VERSION=$(npm view "$PACKAGE_NAME" version)
+            
+          if [ "$NPM_VERSION" != "$PACKAGE_VERSION" ]
+          then
+            npm publish --access public
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} 

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -2,6 +2,7 @@
   "name": "ocaml-protoc-plugin-runtime-bs",
   "namespace": "Ocaml_protoc_plugin",
   "refmt": 3,
+  "bsc-flags" : ["-w", "-44"],
   "sources": [
     {
       "dir": "src/ocaml_protoc_plugin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ocaml-protoc-plugin-runtime-bs",
-  "version": "0.0.1",
+  "version": "3.0.0",
   "description": "BuckleScript runtime for ocaml-protoc-plugin",
   "peerDependencies": {
     "bs-platform": ">=5.0.0"
@@ -19,7 +19,8 @@
   ],
   "license": "Apache-2.0",
   "files": [
-    "./bsconfig.json",
-    "./src/protobuf"
+    "bsconfig.json",
+    "src/ocaml_protoc_plugin"
   ]
 }
+


### PR DESCRIPTION
This PR updates the bucklescript-related files. Btw everything still works well in runtime 👍. Thanks for the maintenance of this repo. For the automated publish script we'd need an npm token of somebody. I used mine for the runtime so far but I can add someone to the repo. I also can add mine to the repo but it'd require giving me some access to the settings.