### PR TITLE
Convert bash to OCaml.

### DIFF
--- a/src/gen/dune
+++ b/src/gen/dune
@@ -1,0 +1,2 @@
+(executable
+ (name gen))

--- a/src/gen/gen.ml
+++ b/src/gen/gen.ml
@@ -1,5 +1,3 @@
-let _ = Sys.getenv "INCLUDE_GOOGLE_PROTOBUF"
-
 let () =
     match Sys.getenv_opt "INCLUDE_GOOGLE_PROTOBUF" with
       Some s -> print_endline s

--- a/src/gen/gen.ml
+++ b/src/gen/gen.ml
@@ -6,11 +6,11 @@ let () =
             let prefix = "/usr/include" in
             let name = Filename.concat prefix suffix in
             if Sys.file_exists name && Sys.is_directory name then
-                print_endline name
+                print_endline prefix
             else
                 let prefix = "/usr/local/include" in
                 let name = Filename.concat prefix suffix in
                 if Sys.file_exists name && Sys.is_directory name then
-                    print_endline name
+                    print_endline prefix
                 else
                     failwith "Where is the include folder ?"

--- a/src/gen/gen.ml
+++ b/src/gen/gen.ml
@@ -1,0 +1,18 @@
+let _ = Sys.getenv "INCLUDE_GOOGLE_PROTOBUF"
+
+let () =
+    match Sys.getenv_opt "INCLUDE_GOOGLE_PROTOBUF" with
+      Some s -> print_endline s
+    | None ->
+            let suffix = "google/protobuf" in
+            let prefix = "/usr/include" in
+            let name = Filename.concat prefix suffix in
+            if Sys.file_exists name && Sys.is_directory name then
+                print_endline name
+            else
+                let prefix = "/usr/local/include" in
+                let name = Filename.concat prefix suffix in
+                if Sys.file_exists name && Sys.is_directory name then
+                    print_endline name
+                else
+                    failwith "Where is the include folder ?"

--- a/src/google_types/dune
+++ b/src/google_types/dune
@@ -7,7 +7,7 @@
 
 (rule
  (targets google_include)
- (action (with-stdout-to %{targets} (system "[ -d /usr/include/google/protobuf ] && echo /usr/include || echo /usr/local/include" ))))
+ (action (with-stdout-to %{targets} (run ../gen/gen.exe ))))
 
 (rule
  (targets any.ml api.ml descriptor.ml duration.ml empty.ml field_mask.ml


### PR DESCRIPTION
Hello,

This PR has 2 goal:
- Reduce dependencies on bash (so the project is more compatible: no issue with weird shell, it now only require dune/ocaml to build)
- Help sandboxing: I use esy a ocaml/reason package manager that sandbox all deps. In esy world we shouldn't require to acces outside world without someone give us a hint where to search. So I introduced: `INCLUDE_GOOGLE_PROTOBUF` that allow to specify where to see files + it has the benefit that it can know work with windows that obviously doesn't have /usr. In case this variable isn't provided we can assumed that we are on opam that run in a unixy env.

remarks: I am not able do execute `dune build @all` is it the current way to build all even the example ? Were they broken before. In any case it isn't a issue has we can use from as dependencies correctly.