### PR TITLE
Derive std for well-known Google types

### DIFF
--- a/ocaml-protoc-plugin.opam
+++ b/ocaml-protoc-plugin.opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "ppx_expect" {with-test}
   "ppx_inline_test" {with-test}
-  "ppx_deriving" {with-test}
+  "ppx_deriving" {>= "5.0"}
 ]
 
 

--- a/src/google_types/dune
+++ b/src/google_types/dune
@@ -3,7 +3,7 @@
  (public_name ocaml-protoc-plugin.google_types)
  (libraries   ocaml_protoc_plugin)
  (preprocess  (pps ppx_deriving.std))
- (synopsis "Google well known types")
+ (synopsis    "Google well known types")
 )
 
 (rule

--- a/src/google_types/dune
+++ b/src/google_types/dune
@@ -18,7 +18,7 @@
  (action
   (run protoc -I %{read-lines:google_include}
        "--plugin=protoc-gen-ocaml=%{plugin}"
-       "--ocaml_out=annot=[@@deriving std]:."
+       "--ocaml_out=annot=[@@deriving ord, eq, show, iter, map, fold]:."
        %{read-lines:google_include}/google/protobuf/any.proto
        %{read-lines:google_include}/google/protobuf/api.proto
        %{read-lines:google_include}/google/protobuf/descriptor.proto

--- a/src/google_types/dune
+++ b/src/google_types/dune
@@ -2,6 +2,7 @@
  (name        google_types)
  (public_name ocaml-protoc-plugin.google_types)
  (libraries   ocaml_protoc_plugin)
+ (preprocess  (pps ppx_deriving.std))
  (synopsis "Google well known types")
 )
 
@@ -17,7 +18,7 @@
  (action
   (run protoc -I %{read-lines:google_include}
        "--plugin=protoc-gen-ocaml=%{plugin}"
-       "--ocaml_out=."
+       "--ocaml_out=annot=[@@deriving std]:."
        %{read-lines:google_include}/google/protobuf/any.proto
        %{read-lines:google_include}/google/protobuf/api.proto
        %{read-lines:google_include}/google/protobuf/descriptor.proto


### PR DESCRIPTION
This is required for everybody that uses the Google types and wants to make them `[@@derive show]` or any other deriver.