### PR TITLE
Enable the int_types_native test only on 64bit architectures

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,6 @@
 (library
  (name test)
+ (enabled_if %{arch_sixtyfour})
  (libraries ocaml_protoc_plugin google_types)
  (inline_tests)
  (preprocess
@@ -37,7 +38,6 @@
  (deps
   (:plugin ../src/plugin/protoc_gen_ocaml.exe)
   (:proto int_types_native.proto int_types_native_proto2.proto))
- (enabled_if %{arch_sixtyfour})
  (action
   (run protoc -I %{read-lines:google_include} -I .
        "--plugin=protoc-gen-ocaml=%{plugin}"

--- a/test/dune
+++ b/test/dune
@@ -37,6 +37,7 @@
  (deps
   (:plugin ../src/plugin/protoc_gen_ocaml.exe)
   (:proto int_types_native.proto int_types_native_proto2.proto))
+ (enabled_if %{arch_sixtyfour})
  (action
   (run protoc -I %{read-lines:google_include} -I .
        "--plugin=protoc-gen-ocaml=%{plugin}"


### PR DESCRIPTION
Should fix the issue experienced in https://github.com/ocaml/opam-repository/pull/18067#issuecomment-772058365