### PR TITLE
do not force google types to be in /usr/include or /usr/local/include

### DIFF
--- a/ocaml-protoc-plugin.opam
+++ b/ocaml-protoc-plugin.opam
@@ -11,6 +11,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "arm32" & arch != "x86_32"}
 ]
+
 depends: [
   "conf-protoc" {>= "1.0.0"}
   "dune" {>= "2.0"}
@@ -18,6 +19,7 @@ depends: [
   "ppx_expect" {with-test}
   "ppx_inline_test" {with-test}
   "ppx_deriving" {with-test}
+  "conf-pkg-config" {build}
 ]
 
 

--- a/src/google_types/dune
+++ b/src/google_types/dune
@@ -7,7 +7,7 @@
 
 (rule
  (targets google_include)
- (action (with-stdout-to %{targets} (system "[ -d /usr/include/google/protobuf ] && echo /usr/include || echo /usr/local/include" ))))
+ (action (with-stdout-to %{targets} (system "[ -d $(dirname %{bin:protoc})/../include/google/protobuf ] && echo $(dirname %{bin:protoc})/../include "))))
 
 (rule
  (targets any.ml api.ml descriptor.ml duration.ml empty.ml field_mask.ml

--- a/src/google_types/dune
+++ b/src/google_types/dune
@@ -7,7 +7,8 @@
 
 (rule
  (targets google_include)
- (action (with-stdout-to %{targets} (system "[ -d $(dirname %{bin:protoc})/../include/google/protobuf ] && echo $(dirname %{bin:protoc})/../include "))))
+ (action (with-stdout-to %{targets}
+          (system "pkg-config protobuf --variable=includedir"))))
 
 (rule
  (targets any.ml api.ml descriptor.ml duration.ml empty.ml field_mask.ml


### PR DESCRIPTION
I've been trying to install ocaml-protoc-plugin in `nix` through [opam2nix](https://github.com/timbertson/opam2nix), and  stumbled upon the fact that in this setting google types are neither in `/usr/include` nor in `/usr/local/include`, as assumed by the `dune` rule in `src/google_types`, but somewhere in `/nix/store/xxxxxxxx-protobuf-vn.n.n/include`. The proposed patch assumes that `include` is a sibling of the `bin` directory where `protoc` lies (if `protoc` is not in the `PATH` at this point, the build will fail anyway).