### PR TITLE
Use `run` not to depend on the system shell

### DIFF
--- a/src/google_types/dune
+++ b/src/google_types/dune
@@ -8,7 +8,7 @@
 (rule
  (targets google_include)
  (action (with-stdout-to %{targets}
-          (system "pkg-config protobuf --variable=includedir"))))
+          (run pkg-config protobuf --variable=includedir))))
 
 (rule
  (targets any.ml api.ml descriptor.ml duration.ml empty.ml field_mask.ml


### PR DESCRIPTION
When using `system` in `action` clause, it runs `/path/to/bin/sh -c 'pkg-config protobuf --variable=includedir'`.
This PR changes to run `pkg-config` directly (`/path/to/bin/pkg-config protobuf --variable=includedir`) on the *current* `PATH`.