### PR TITLE
Cleanup remaining bits from #28.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,5 @@
+- [x] Emit modules for service endpoints with request/reply and gRPC
+      endpoint name (thanks @Nymphium)
 - [x] Support importing from proto files with `-` in their name.
 
 ## 4.3.1: 2022-09-12

--- a/src/plugin/emit.ml
+++ b/src/plugin/emit.ml
@@ -58,16 +58,18 @@ let emit_service_type scope ServiceDescriptorProto.{ name; method' = methods; _ 
   let emit_method t local_scope scope MethodDescriptorProto.{ name; input_type; output_type; _} =
     let name = Option.value_exn name in
     let uncapitalized_name = String.uncapitalize_ascii name |> Scope.Local.get_unique_name local_scope in
-    (* To keep symmetry, only ensure that lowercased names are unique so that the upper case names are aswell.
-       We should remove this mapping if/when we deprecate the old API *)
+    (* To keep symmetry, only ensure that lowercased names are unique
+       so that the upper case names are aswell.  We should remove this
+       mapping if/when we deprecate the old API *)
     let capitalized_name = String.capitalize_ascii uncapitalized_name in
-    let service_name = Scope.get_rpc_path scope in
+
+    let service_name = Scope.get_proto_path scope in
     let input = Scope.get_scoped_name scope input_type in
     let input_t = Scope.get_scoped_name scope ~postfix:"t" input_type in
     let output = Scope.get_scoped_name scope output_type in
     let output_t = Scope.get_scoped_name scope ~postfix:"t" output_type  in
     Code.emit t `Begin "module %s = struct" capitalized_name;
-    Code.emit t `None "let name = \"%s/%s\"" service_name name;
+    Code.emit t `None "let name = \"/%s/%s\"" service_name name;
     Code.emit t `None "module Request = %s" input;
     Code.emit t `None "module Response = %s" output;
     Code.emit t `End "end";

--- a/src/plugin/emit.ml
+++ b/src/plugin/emit.ml
@@ -55,15 +55,13 @@ let emit_enum_type ~scope ~params
   {module_name; signature; implementation}
 
 let emit_service_type scope ServiceDescriptorProto.{ name; method' = methods; _ } =
-  let emit_method t scope MethodDescriptorProto.{ name; input_type; output_type; _} =
-    let get_unique_name =
-      let open Names.Rpc in
-      let t = init () in
-      get_unique_name t in
-    let name = get_unique_name @@ Scope.get_name_exn scope name in
-    let uncapitalized_name = Names.field_name name in
-    let capitalized_name = String.capitalize_ascii name in
-    let service_name = Option.value_map ~default:"" ~f:((^) "/") @@ Scope.get_current_proto_path scope in
+  let emit_method t local_scope scope MethodDescriptorProto.{ name; input_type; output_type; _} =
+    let name = Option.value_exn name in
+    let uncapitalized_name = String.uncapitalize_ascii name |> Scope.Local.get_unique_name local_scope in
+    (* To keep symmetry, only ensure that lowercased names are unique so that the upper case names are aswell.
+       We should remove this mapping if/when we deprecate the old API *)
+    let capitalized_name = String.capitalize_ascii uncapitalized_name in
+    let service_name = Scope.get_rpc_path scope in
     let input = Scope.get_scoped_name scope input_type in
     let input_t = Scope.get_scoped_name scope ~postfix:"t" input_type in
     let output = Scope.get_scoped_name scope output_type in
@@ -73,18 +71,22 @@ let emit_service_type scope ServiceDescriptorProto.{ name; method' = methods; _ 
     Code.emit t `None "module Request = %s" input;
     Code.emit t `None "module Response = %s" output;
     Code.emit t `End "end";
-    Code.emit t `None "let %s = " uncapitalized_name;
-    Code.emit t `None "( (module %s : Runtime'.Service.Message with type t = %s ), "
+    Code.emit t `Begin "let %s = " uncapitalized_name;
+    Code.emit t `None "(module %s : Runtime'.Service.Message with type t = %s ), "
       input
       input_t;
-    Code.emit t `None "  (module %s : Runtime'.Service.Message with type t = %s ) ) "
+    Code.emit t `None "(module %s : Runtime'.Service.Message with type t = %s )"
       output
       output_t;
+    Code.emit t `End "";
+    ()
   in
   let name = Option.value_exn ~message:"Service definitions must have a name" name in
   let t = Code.init () in
   Code.emit t `Begin "module %s = struct" (Scope.get_name scope name);
-  List.iter ~f:(emit_method t (Scope.push scope name)) methods;
+  let local_scope = Scope.Local.init () in
+
+  List.iter ~f:(emit_method t local_scope (Scope.push scope name)) methods;
   Code.emit t `End "end";
   t
 

--- a/src/plugin/names.ml
+++ b/src/plugin/names.ml
@@ -43,16 +43,10 @@ let to_snake_case ident =
   |> String.lowercase_ascii
   |> String.capitalize_ascii
 
-let field_name ?(uncapitalize=true) ?(mangle_f=(fun x -> x)) field_name =
-  let name = 
-    let name =  mangle_f field_name in
-    match uncapitalize with 
-    | true -> String.uncapitalize_ascii name
-    | false -> name 
-  in
-  match is_reserved name with
-  | true -> name ^ "'"
-  | false -> name 
+let field_name ?(mangle_f=(fun x -> x)) field_name =
+  match String.uncapitalize_ascii (mangle_f field_name) with
+  | name when is_reserved name -> name ^ "'"
+  | name -> name
 
 let module_name ?(mangle_f=(fun x -> x)) name =
   let name = mangle_f name in
@@ -62,18 +56,3 @@ let module_name ?(mangle_f=(fun x -> x)) name =
 
 let poly_constructor_name ?(mangle_f=(fun x -> x)) name =
   "`" ^ (mangle_f name |> String.capitalize_ascii)
-
-(** Local map with rpc name and ocaml variable name  *)
-module Rpc = struct
-  type t = (string, unit) Hashtbl.t
-  let init () : t = Hashtbl.create 2
-  let get_unique_name t preferred_name = 
-    let rec inner name = 
-      match Hashtbl.mem t name with
-      | false -> name
-      | true -> inner (name ^ "'")
-   in 
-   let name = inner preferred_name in
-   Hashtbl.add t name ();
-   name
-end

--- a/src/plugin/scope.ml
+++ b/src/plugin/scope.ml
@@ -15,7 +15,7 @@ module StringMap = struct
 end
 module StringSet = Set.Make(String)
 
-(** Module to avoid name slashes in a local scope *)
+(** Module to avoid name clashes in a local scope *)
 module Local = struct
   type t = (string, unit) Hashtbl.t
   let init () : t = Hashtbl.create 2

--- a/src/plugin/scope.ml
+++ b/src/plugin/scope.ml
@@ -359,10 +359,10 @@ let get_current_scope t =
   let { module_name; ocaml_name = _; _ } = StringMap.find t.proto_path t.type_db in
   (String.lowercase_ascii module_name) ^ t.proto_path
 
-let get_rpc_path { proto_path; _ } =
+let get_proto_path { proto_path; _ } =
   match String.split_on_char ~sep:'.'  proto_path with
-  | _ :: path -> "/" ^ String.concat ~sep:"." path
-  | [] -> ""
+  | _ :: path -> String.concat ~sep:"." path
+  | [] -> failwith "proto path must be called within a service scope"
 
 let is_cyclic t =
   let { cyclic; _ } = StringMap.find t.proto_path t.type_db in

--- a/src/plugin/scope.mli
+++ b/src/plugin/scope.mli
@@ -30,7 +30,7 @@ val get_name_exn : t -> string option -> string
 (** Get the type of the curren scope *)
 val get_current_scope : t -> string
 
-(** Get the path of the given scope,  *)
+(** Get the path of the given scope  *)
 val get_rpc_path : t -> string
 
 (** Tell if the type pointed to by the current scope is part of a cycle. *)

--- a/src/plugin/scope.mli
+++ b/src/plugin/scope.mli
@@ -30,8 +30,9 @@ val get_name_exn : t -> string option -> string
 (** Get the type of the curren scope *)
 val get_current_scope : t -> string
 
-(** Get the path of the given scope  *)
-val get_rpc_path : t -> string
+(** Get the gRPC proto path, as defined by the gRPC http2 spec
+    see https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#appendix-a---grpc-for-protobuf *)
+val get_proto_path : t -> string
 
 (** Tell if the type pointed to by the current scope is part of a cycle. *)
 val is_cyclic: t -> bool

--- a/src/plugin/scope.mli
+++ b/src/plugin/scope.mli
@@ -1,3 +1,9 @@
+module Local : sig
+  type t
+  val init: unit -> t
+  val get_unique_name: t -> string -> string
+end
+
 type t
 val init : Spec.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> t
 
@@ -24,8 +30,8 @@ val get_name_exn : t -> string option -> string
 (** Get the type of the curren scope *)
 val get_current_scope : t -> string
 
-(**  Get the path of the given scpoe *)
-val get_current_proto_path : t -> string option
+(** Get the path of the given scope,  *)
+val get_rpc_path : t -> string
 
 (** Tell if the type pointed to by the current scope is part of a cycle. *)
 val is_cyclic: t -> bool

--- a/test/service_rpc_clash.proto
+++ b/test/service_rpc_clash.proto
@@ -11,5 +11,7 @@ service Test {
   rpc call (Request) returns (Response);
   rpc CALL (Request) returns (Response);
   rpc cALL (Request) returns (Response);
+  rpc Method (Request) returns (Response);
+  rpc functor (Request) returns (Response);
+  rpc Functor (Request) returns (Response);
 }
-


### PR DESCRIPTION
This includes:
 - a fix for name clashes
 - use the actual name of the rpc endpoint for the name inside the module structure.
 - remove unused functions
 - revert unneeded changes
 - Move local scope handling to scope
 - Make emitted names in the service module more predicable. (the module will be the capitalized name of the service value)
 - Add tests for using reserved names