### PR TITLE
Quality of life enhancements for RPC modules

### DIFF
--- a/src/plugin/emit.ml
+++ b/src/plugin/emit.ml
@@ -67,9 +67,12 @@ let emit_service_type scope ServiceDescriptorProto.{ name; method' = methods; _ 
     let input = Scope.get_scoped_name scope input_type in
     let input_t = Scope.get_scoped_name scope ~postfix:"t" input_type in
     let output = Scope.get_scoped_name scope output_type in
-    let output_t = Scope.get_scoped_name scope ~postfix:"t" output_type  in
+    let output_t = Scope.get_scoped_name scope ~postfix:"t" output_type in
     Code.emit t `Begin "module %s = struct" capitalized_name;
     Code.emit t `None "let name = \"/%s/%s\"" service_name name;
+    Code.emit t `None "let service = \"%s\"" service_name;
+    Code.emit t `None "let rpc = \"%s\"" name;
+
     Code.emit t `None "module Request = %s" input;
     Code.emit t `None "module Response = %s" output;
     Code.emit t `End "end";
@@ -201,6 +204,8 @@ let rec emit_message ~params ~syntax scope
       Code.emit signature `None "val make : %s" default_constructor_sig;
       Code.emit signature `None "val to_proto: t -> Runtime'.Writer.t";
       Code.emit signature `None "val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result";
+      Code.emit signature `None "val encode: t -> string";
+      Code.emit signature `None "val decode: string -> (t, [> Runtime'.Result.error]) result";
 
       Code.emit implementation `None "let name' () = \"%s\"" (Scope.get_current_scope scope);
       Code.emit implementation `None "type t = %s%s" type' params.annot;
@@ -221,6 +226,9 @@ let rec emit_message ~params ~syntax scope
       Code.emit implementation `None "let deserialize = Runtime'.Deserialize.deserialize %s spec constructor in" extension_ranges;
       Code.emit implementation `None "fun writer -> deserialize writer |> Runtime'.Result.open_error";
       Code.emit implementation `End "";
+
+      Code.emit implementation `None "let encode t = to_proto t |> Runtime'.Writer.contents";
+      Code.emit implementation `None "let decode s = Runtime'.Reader.create s |> from_proto";
     | None -> ()
   in
   {module_name; signature; implementation}


### PR DESCRIPTION
Quality of life enhancements for RPC modules `service`, `rpc`, `encode`, `decode`. This cleans up the calling code for ocaml-grpc.

For the Greeter gRPC example of:
``` protobuf
syntax = "proto3";
package mypackage;

// The greeting service definition.
service Greeter {
  // Sends a greeting
  rpc SayHello(HelloRequest) returns (HelloReply) {}
}

// The request message containing the user's name.
message HelloRequest { string name = 1; }

// The response message containing the greetings
message HelloReply { string message = 1; }

```
This change produces this code:
``` ocaml
  module Greeter = struct
    module SayHello = struct
      let name = "/mypackage.Greeter/SayHello"
      let service = "mypackage.Greeter"
      let rpc = "SayHello"
      module Request = HelloRequest
      module Response = HelloReply
    end
    let sayHello = 
      (module HelloRequest : Runtime'.Service.Message with type t = HelloRequest.t ), 
      (module HelloReply : Runtime'.Service.Message with type t = HelloReply.t )
    
  end
```
Calling this code can then be configured with the generated types rather than using strings. For example:
```ocaml
let server =
  let open Greeter.Mypackage in
  let greeter_service =
    Server.Service.(
      v () |> add_rpc ~name:Greeter.SayHello.rpc ~rpc:(Unary say_hello) |> handle_request)
  in
  Server.(
    v () |> add_service ~name:Greeter.SayHello.service ~service:greeter_service)
```