### PR TITLE
Add extra fields to RPC endpoints

### DIFF
--- a/src/ocaml_protoc_plugin/service.ml
+++ b/src/ocaml_protoc_plugin/service.ml
@@ -7,7 +7,20 @@ end
 module type Rpc = sig
   module Request : Message
   module Response : Message
+
+  (** gRPC service name as defined by the gRPC http2 spec.
+      see https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#appendix-a---grpc-for-protobuf
+  *)
   val name : string
+
+  (** Name of the enclosed package name if any *)
+  val package_name : string option
+
+  (** Name of the service in which this method is defined *)
+  val service_name : string
+
+  (** Name of the method *)
+  val method_name : string
 end
 
 let make_client_functions (type req) (type rep)

--- a/src/plugin/emit.ml
+++ b/src/plugin/emit.ml
@@ -63,20 +63,21 @@ let emit_service_type scope ServiceDescriptorProto.{ name; method' = methods; _ 
        mapping if/when we deprecate the old API *)
     let capitalized_name = String.capitalize_ascii uncapitalized_name in
 
-    let package_name = Scope.get_package_name scope in
-    let service_path =
-      let package = Option.value_map ~default:"" ~f:(fun v -> v ^ ".") package_name in
-      package ^ service_name
+    let package_name_opt = Scope.get_package_name scope in
+    let package_name =
+      match package_name_opt with
+        | None -> ""
+        | Some p -> p ^ "."
     in
     let input = Scope.get_scoped_name scope input_type in
     let input_t = Scope.get_scoped_name scope ~postfix:"t" input_type in
     let output = Scope.get_scoped_name scope output_type in
     let output_t = Scope.get_scoped_name scope ~postfix:"t" output_type in
     Code.emit t `Begin "module %s = struct" capitalized_name;
-    Code.emit t `None "let package_name = %s" (Option.value_map ~default:"None" ~f:(fun n -> sprintf "Some \"%s\"" n) package_name);
+    Code.emit t `None "let package_name = %s" (Option.value_map ~default:"None" ~f:(fun n -> sprintf "Some \"%s\"" n) package_name_opt);
     Code.emit t `None "let service_name = \"%s\"" service_name;
     Code.emit t `None "let method_name = \"%s\"" name;
-    Code.emit t `None "let name = \"/%s/%s\"" service_path name;
+    Code.emit t `None "let name = \"/%s%s/%s\"" package_name service_name name;
     Code.emit t `None "module Request = %s" input;
     Code.emit t `None "module Response = %s" output;
     Code.emit t `End "end";

--- a/src/plugin/emit.ml
+++ b/src/plugin/emit.ml
@@ -263,8 +263,8 @@ let parse_proto_file ~params scope
   in
   let message_type =
     DescriptorProto.{name = None; nested_type=message_types; enum_type = enum_types;
-                                field = []; extension; extension_range = []; oneof_decl = [];
-                                options = None; reserved_range = []; reserved_name = []; }
+                     field = []; extension; extension_range = []; oneof_decl = [];
+                     options = None; reserved_range = []; reserved_name = []; }
   in
   let implementation = Code.init () in
 

--- a/src/plugin/emit.ml
+++ b/src/plugin/emit.ml
@@ -55,7 +55,7 @@ let emit_enum_type ~scope ~params
   {module_name; signature; implementation}
 
 let emit_service_type scope ServiceDescriptorProto.{ name; method' = methods; _ } =
-  let emit_method t local_scope scope MethodDescriptorProto.{ name; input_type; output_type; _} =
+  let emit_method t local_scope scope service_name MethodDescriptorProto.{ name; input_type; output_type; _} =
     let name = Option.value_exn name in
     let uncapitalized_name = String.uncapitalize_ascii name |> Scope.Local.get_unique_name local_scope in
     (* To keep symmetry, only ensure that lowercased names are unique
@@ -63,13 +63,20 @@ let emit_service_type scope ServiceDescriptorProto.{ name; method' = methods; _ 
        mapping if/when we deprecate the old API *)
     let capitalized_name = String.capitalize_ascii uncapitalized_name in
 
-    let service_name = Scope.get_proto_path scope in
+    let package_name = Scope.get_package_name scope in
+    let service_path =
+      let package = Option.value_map ~default:"" ~f:(fun v -> v ^ ".") package_name in
+      package ^ service_name
+    in
     let input = Scope.get_scoped_name scope input_type in
     let input_t = Scope.get_scoped_name scope ~postfix:"t" input_type in
     let output = Scope.get_scoped_name scope output_type in
-    let output_t = Scope.get_scoped_name scope ~postfix:"t" output_type  in
+    let output_t = Scope.get_scoped_name scope ~postfix:"t" output_type in
     Code.emit t `Begin "module %s = struct" capitalized_name;
-    Code.emit t `None "let name = \"/%s/%s\"" service_name name;
+    Code.emit t `None "let package_name = %s" (Option.value_map ~default:"None" ~f:(fun n -> sprintf "Some \"%s\"" n) package_name);
+    Code.emit t `None "let service_name = \"%s\"" service_name;
+    Code.emit t `None "let method_name = \"%s\"" name;
+    Code.emit t `None "let name = \"/%s/%s\"" service_path name;
     Code.emit t `None "module Request = %s" input;
     Code.emit t `None "module Response = %s" output;
     Code.emit t `End "end";
@@ -88,7 +95,7 @@ let emit_service_type scope ServiceDescriptorProto.{ name; method' = methods; _ 
   Code.emit t `Begin "module %s = struct" (Scope.get_name scope name);
   let local_scope = Scope.Local.init () in
 
-  List.iter ~f:(emit_method t local_scope (Scope.push scope name)) methods;
+  List.iter ~f:(emit_method t local_scope (Scope.push scope name) name) methods;
   Code.emit t `End "end";
   t
 

--- a/src/plugin/scope.ml
+++ b/src/plugin/scope.ml
@@ -359,10 +359,11 @@ let get_current_scope t =
   let { module_name; ocaml_name = _; _ } = StringMap.find t.proto_path t.type_db in
   (String.lowercase_ascii module_name) ^ t.proto_path
 
-let get_proto_path { proto_path; _ } =
+let get_package_name { proto_path; _ } =
   match String.split_on_char ~sep:'.'  proto_path with
-  | _ :: path -> String.concat ~sep:"." path
-  | [] -> failwith "proto path must be called within a service scope"
+  | [ _module; package; _service ] -> Some package
+  | [ _module; _service ] -> None
+  | _ -> failwith "proto path must be called within a service scope"
 
 let is_cyclic t =
   let { cyclic; _ } = StringMap.find t.proto_path t.type_db in

--- a/src/plugin/scope.ml
+++ b/src/plugin/scope.ml
@@ -360,10 +360,9 @@ let get_current_scope t =
   (String.lowercase_ascii module_name) ^ t.proto_path
 
 let get_package_name { proto_path; _ } =
-  match String.split_on_char ~sep:'.'  proto_path with
-  | [ _module; package; _service ] -> Some package
-  | [ _module; _service ] -> None
-  | _ -> failwith "proto path must be called within a service scope"
+  match String.split_on_char ~sep:'.' proto_path with
+  | _ :: xs -> List.rev xs |> List.tl |> List.rev |> String.concat ~sep:"." |> Option.some
+  | _ -> None
 
 let is_cyclic t =
   let { cyclic; _ } = StringMap.find t.proto_path t.type_db in

--- a/src/plugin/scope.mli
+++ b/src/plugin/scope.mli
@@ -30,9 +30,8 @@ val get_name_exn : t -> string option -> string
 (** Get the type of the curren scope *)
 val get_current_scope : t -> string
 
-(** Get the gRPC proto path, as defined by the gRPC http2 spec
-    see https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#appendix-a---grpc-for-protobuf *)
-val get_proto_path : t -> string
+(** Get the package name. This function assumes callee is in service scope *)
+val get_package_name : t -> string option
 
 (** Tell if the type pointed to by the current scope is part of a cycle. *)
 val is_cyclic: t -> bool

--- a/test/service.proto
+++ b/test/service.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package service;
+package service.p1.p2.p3;
 
 message Request {
   uint64 i = 1;

--- a/test/service_test.ml
+++ b/test/service_test.ml
@@ -1,7 +1,8 @@
 open Service
+module S = Service.P1.P2.P3
 let service reader =
   let (s_deser, s_ser) =
-    Ocaml_protoc_plugin.Service.make_service_functions Service.String_of_int.call
+    Ocaml_protoc_plugin.Service.make_service_functions S.String_of_int.call
   in
   let req =
     s_deser reader
@@ -11,7 +12,7 @@ let service reader =
 
 let call i =
   let (c_ser, c_deser) =
-    Ocaml_protoc_plugin.Service.make_client_functions Service.String_of_int.call
+    Ocaml_protoc_plugin.Service.make_client_functions S.String_of_int.call
   in
   let req = i in
   req
@@ -25,13 +26,13 @@ let call i =
   |> (function Ok r -> r | Error _ -> failwith "Error")
 
 let%expect_test _ =
-  Caml.Printf.printf "name: \"%s\"\n" Service.String_of_int.Call.name;
-  Caml.Printf.printf "package_name: \"%s\"\n" @@ Option.value ~default:"<none>" Service.String_of_int.Call.package_name;
-  Caml.Printf.printf "service_name: \"%s\"\n" Service.String_of_int.Call.service_name;
-  Caml.Printf.printf "method_name: \"%s\"\n" Service.String_of_int.Call.method_name;
+  Caml.Printf.printf "name: \"%s\"\n" S.String_of_int.Call.name;
+  Caml.Printf.printf "package_name: \"%s\"\n" @@ Option.value ~default:"<none>" S.String_of_int.Call.package_name;
+  Caml.Printf.printf "service_name: \"%s\"\n" S.String_of_int.Call.service_name;
+  Caml.Printf.printf "method_name: \"%s\"\n" S.String_of_int.Call.method_name;
   [%expect {|
-    name: "/service.String_of_int/Call"
-    package_name: "service"
+    name: "/service.p1.p2.p3.String_of_int/Call"
+    package_name: "service.p1.p2.p3"
     service_name: "String_of_int"
     method_name: "Call" |}]
 

--- a/test/service_test.ml
+++ b/test/service_test.ml
@@ -25,6 +25,17 @@ let call i =
   |> (function Ok r -> r | Error _ -> failwith "Error")
 
 let%expect_test _ =
+  Caml.Printf.printf "name: \"%s\"\n" Service.String_of_int.Call.name;
+  Caml.Printf.printf "package_name: \"%s\"\n" @@ Option.value ~default:"<none>" Service.String_of_int.Call.package_name;
+  Caml.Printf.printf "service_name: \"%s\"\n" Service.String_of_int.Call.service_name;
+  Caml.Printf.printf "method_name: \"%s\"\n" Service.String_of_int.Call.method_name;
+  [%expect {|
+    name: "/service.String_of_int/Call"
+    package_name: "service"
+    service_name: "String_of_int"
+    method_name: "Call" |}]
+
+let%expect_test _ =
   Caml.Printf.printf "%d -> \"%s\"\n" 0 (call 0);
   Caml.Printf.printf "%d -> \"%s\"\n" 5 (call 5);
   Caml.Printf.printf "%d -> \"%s\"\n" 50 (call 50);


### PR DESCRIPTION
Add `service_name`, `method_name` and `package_name` to RPC modules. 

Closes #49 
