### PR TITLE
Fix upper case matching in name mangling.

### DIFF
--- a/src/plugin/names.ml
+++ b/src/plugin/names.ml
@@ -24,7 +24,7 @@ let to_snake_case ident =
   in
   let char_case = function
     | 'a' .. 'z' -> `Lower
-    | 'A' .. 'Z' -> `upper
+    | 'A' .. 'Z' -> `Upper
     | _ -> `Neither
   in
   let is_lower c = char_case c = `Lower in


### PR DESCRIPTION
Note: It fixed messages but services and methods are not mangled properly:

```OCaml
module Greeter = struct
  module SayHello = struct
    let package_name = Some "ocxmr.greeter_async.proto"
    let service_name = "Greeter"
    let method_name = "SayHello"
    let name = "/ocxmr.greeter_async.proto.Greeter/SayHello"
    module Request = Hello_request
    module Response = Hello_reply
  end
  let sayHello = 
    (module Hello_request : Runtime'.Service.Message with type t = Hello_request.t ), 
    (module Hello_reply : Runtime'.Service.Message with type t = Hello_reply.t )
end
```