### PR TITLE
Convert tests into expect tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,7 +12,7 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-compiler:
-          - 5.0.0
+          - 5
           - 4.08.0
 
     runs-on: ${{ matrix.os }}

--- a/examples/echo/dune
+++ b/examples/echo/dune
@@ -14,8 +14,8 @@
   (:proto echo.proto) (package ocaml-protoc-plugin))
  (action
   (run protoc -I %{read-lines:google_include} -I . "--ocaml_out=open=Google_types:." %{proto})))
-
-(alias
- (name runtest)
+(rule
  (deps test.exe)
+ (action (ignore-stdout (run %{deps})))
+ (alias runtest)
 )

--- a/examples/echo_deriving/dune
+++ b/examples/echo_deriving/dune
@@ -22,7 +22,8 @@
        %{proto}))
 )
 
-(alias
- (name runtest)
+(rule
  (deps test.exe)
+ (action (ignore-stdout (run %{deps})))
+ (alias runtest)
 )

--- a/src/ocaml_protoc_plugin/dune
+++ b/src/ocaml_protoc_plugin/dune
@@ -2,4 +2,6 @@
  (name ocaml_protoc_plugin)
  (public_name ocaml-protoc-plugin)
  (synopsis "Serialization and deserialization of protobuf types")
+ (inline_tests)
+ (preprocess (pps ppx_expect))
 )

--- a/src/ocaml_protoc_plugin/ocaml_protoc_plugin.ml
+++ b/src/ocaml_protoc_plugin/ocaml_protoc_plugin.ml
@@ -10,11 +10,3 @@ module Writer = Writer
 module Service = Service
 module Result = Result
 module Extensions = Extensions
-
-(**/**)
-
-let test () =
-  Writer.Test.test ();
-  Serialize.Test.test ();
-  ()
-(**/**)

--- a/src/ocaml_protoc_plugin/serialize.ml
+++ b/src/ocaml_protoc_plugin/serialize.ml
@@ -23,6 +23,7 @@ let signed_varint v =
   in
   Field.Varint v
 
+
 let rec field_of_spec: type a. a spec -> a -> Field.t = function
   | Double -> fun v -> Fixed_64_bit (Int64.bits_of_float v)
   | Float -> fun v -> Fixed_32_bit (Int32.bits_of_float v)
@@ -144,13 +145,18 @@ let serialize extension_ranges spec =
     serialize writer
 
 
-module Test = struct
-  let test () =
-    let (_:bool) = signed_varint 0L = Varint 0L || failwith "signed_varint 0L" in
-    let (_:bool) = signed_varint (-1L) = Varint 1L || failwith "signed_varint -1L" in
-    let (_:bool) = signed_varint 1L = Varint 2L || failwith "signed_varint 1L" in
-    let (_:bool) = signed_varint (-2L) = Varint 3L || failwith "signed_varint -2L" in
-    let (_:bool) = signed_varint 2147483647L = Varint 4294967294L || failwith "signed_varint 2147483647L" in
-    let (_:bool) = signed_varint (-2147483648L) = Varint 4294967295L || failwith "signed_varint -2147483648L" in
+let%expect_test "signed varint" =
+  let test v =
+    let vl = Int64.of_int v in
+    Printf.printf "signed_varint %LdL = %s\n" vl (signed_varint vl |> Field.show);
     ()
-end
+  in
+  List.iter ~f:test [0; -1; 1; -2; 2; 2147483647; -2147483648];
+  [%expect {|
+    signed_varint 0L = (Field.Varint 0L)
+    signed_varint -1L = (Field.Varint 1L)
+    signed_varint 1L = (Field.Varint 2L)
+    signed_varint -2L = (Field.Varint 3L)
+    signed_varint 2L = (Field.Varint 4L)
+    signed_varint 2147483647L = (Field.Varint 4294967294L)
+    signed_varint -2147483648L = (Field.Varint 4294967295L) |}]

--- a/src/ocaml_protoc_plugin/writer.ml
+++ b/src/ocaml_protoc_plugin/writer.ml
@@ -135,14 +135,8 @@ let of_list: (int * Field.t) list -> t = fun fields ->
   List.iter ~f:(fun (index, field) -> write_field t index field) fields;
   t
 
-
-module Test = struct
-  let test () =
-    let (_:bool) =
-      let buffer = init () in
-      write_field buffer 1 (Varint 1L);
-      let c = contents buffer in
-      String.length c = 2 && String.equal c "\x08\x01" || failwith "Writefield failed"
-    in
-    ()
-end
+let%expect_test "Writefield" =
+  let buffer = init () in
+  write_field buffer 1 (Varint 1L);
+  dump buffer;
+  [%expect {| Buffer: 08-01 |}]

--- a/src/ocaml_protoc_plugin/writer.mli
+++ b/src/ocaml_protoc_plugin/writer.mli
@@ -20,7 +20,4 @@ val write_field : t -> int -> Field.t -> unit
 val add_field : t -> Field.t -> unit
 val concat_as_length_delimited : t -> src:t -> int -> unit
 val dump : t -> unit
-module Test: sig
-  val test: unit -> unit
-end
 (**/**)

--- a/test/runtime.ml
+++ b/test/runtime.ml
@@ -1,1 +1,0 @@
-Ocaml_protoc_plugin.test ()


### PR DESCRIPTION
This PR allows for expect tests in `src/ocaml_protoc_plugin`, and converts existing tests to expect tests, simplifying test writing and removes test from release binaries