### PR TITLE
Improve handling of extensions. 

### DIFF
--- a/src/ocaml_protoc_plugin/deserialize.mli
+++ b/src/ocaml_protoc_plugin/deserialize.mli
@@ -1,5 +1,5 @@
 module C = Spec.Deserialize.C
 
-val deserialize: (int * int) list ->
-  ('constr, (int * Field.t) list -> 'a) Spec.Deserialize.compound_list ->
+val deserialize:
+  ('constr, 'a) Spec.Deserialize.compound_list ->
   'constr -> Reader.t -> 'a

--- a/src/ocaml_protoc_plugin/extensions.ml
+++ b/src/ocaml_protoc_plugin/extensions.ml
@@ -17,11 +17,11 @@ let index_of_spec: type a. a Spec.Serialize.compound -> int = function
 let get: type a. a Spec.Deserialize.compound -> t -> a = fun spec t ->
   let writer = Writer.of_list t in
   let reader = Writer.contents writer |> Reader.create in
-  Deserialize.deserialize [] Spec.Deserialize.(Cons (spec, Nil)) (fun a _ -> a) reader
+  Deserialize.deserialize Spec.Deserialize.(Cons (spec, Nil)) (fun a -> a) reader
 
 let set: type a. a Spec.Serialize.compound -> t -> a -> t = fun spec t v ->
   let writer = Writer.init () in
-  let writer = Serialize.serialize [] Spec.Serialize.(Cons (spec, Nil)) [] writer v in
+  let writer = Serialize.serialize Spec.Serialize.(Cons (spec, Nil)) writer v in
   let index = index_of_spec spec in
   let fields =
     Writer.contents writer

--- a/src/ocaml_protoc_plugin/spec.ml
+++ b/src/ocaml_protoc_plugin/spec.ml
@@ -5,6 +5,8 @@ end
 module Make(T : T) = struct
 
   type packed = Packed | Not_packed
+  type extension_ranges = (int * int) list
+  type extensions = (int * Field.t) list
 
   type _ spec =
     | Double : float spec
@@ -51,6 +53,7 @@ module Make(T : T) = struct
 
   type (_, _) compound_list =
     | Nil : ('a, 'a) compound_list
+    | Nil_ext: extension_ranges -> (extensions -> 'a, 'a) compound_list
     | Cons : ('a compound) * ('b, 'c) compound_list -> ('a -> 'b, 'c) compound_list
 
   module C = struct
@@ -99,6 +102,7 @@ module Make(T : T) = struct
 
     let ( ^:: ) a b = Cons (a, b)
     let nil = Nil
+    let nil_ext extension_ranges = Nil_ext extension_ranges
 
     let show: type a. a spec -> string = function
       | Double -> "Double"

--- a/src/plugin/parse.ml
+++ b/src/plugin/parse.ml
@@ -1,9 +1,3 @@
-(* Should we generate an ast????
-   It would be simpler, and then generate the code based on that one
-   The question is if this is actually harder than just parsing and emitting                                             OTOH: Its easier to create interfaces and modules once we know all the types.
-   We also need to do a lexiographic ordering. No I dont!!!
-*)
-
 type t = {
   filename : string;
   package : string option;

--- a/src/plugin/types.mli
+++ b/src/plugin/types.mli
@@ -26,6 +26,6 @@ val make:
   syntax:[ `Proto2 | `Proto3 ] ->
   is_cyclic: bool ->
   is_map_entry: bool ->
-  has_extensions: bool ->
+  extension_ranges: (int*int) list ->
   scope:Scope.t ->
   fields:FieldDescriptorProto.t list -> OneofDescriptorProto.t list -> t

--- a/src/spec/descriptor.ml
+++ b/src/spec/descriptor.ml
@@ -23,7 +23,7 @@ module rec Google : sig
     module rec FileDescriptorSet : sig
       val name': unit -> string
       type t = FileDescriptorProto.t list
-      val make : ?file:FileDescriptorProto.t list -> unit -> t
+      val make: ?file:FileDescriptorProto.t list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -32,7 +32,7 @@ module rec Google : sig
     and FileDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; package: string option; dependency: string list; message_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; service: ServiceDescriptorProto.t list; extension: FieldDescriptorProto.t list; options: FileOptions.t option; source_code_info: SourceCodeInfo.t option; public_dependency: int list; weak_dependency: int list; syntax: string option }
-      val make : ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
+      val make: ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -42,7 +42,7 @@ module rec Google : sig
       module rec ExtensionRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
-        val make : ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
+        val make: ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -51,7 +51,7 @@ module rec Google : sig
       and ReservedRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option }
-        val make : ?start:int -> ?end':int -> unit -> t
+        val make: ?start:int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -59,7 +59,7 @@ module rec Google : sig
       end
       val name': unit -> string
       type t = { name: string option; field: FieldDescriptorProto.t list; nested_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; extension_range: ExtensionRange.t list; extension: FieldDescriptorProto.t list; options: MessageOptions.t option; oneof_decl: OneofDescriptorProto.t list; reserved_range: ReservedRange.t list; reserved_name: string list }
-      val make : ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      val make: ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -67,8 +67,8 @@ module rec Google : sig
     end
     and ExtensionRangeOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -89,7 +89,7 @@ module rec Google : sig
       end
       val name': unit -> string
       type t = { name: string option; extendee: string option; number: int option; label: Label.t option; type': Type.t option; type_name: string option; default_value: string option; options: FieldOptions.t option; oneof_index: int option; json_name: string option; proto3_optional: bool option }
-      val make : ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
+      val make: ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -98,7 +98,7 @@ module rec Google : sig
     and OneofDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; options: OneofOptions.t option }
-      val make : ?name:string -> ?options:OneofOptions.t -> unit -> t
+      val make: ?name:string -> ?options:OneofOptions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -108,7 +108,7 @@ module rec Google : sig
       module rec EnumReservedRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option }
-        val make : ?start:int -> ?end':int -> unit -> t
+        val make: ?start:int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -116,7 +116,7 @@ module rec Google : sig
       end
       val name': unit -> string
       type t = { name: string option; value: EnumValueDescriptorProto.t list; options: EnumOptions.t option; reserved_range: EnumReservedRange.t list; reserved_name: string list }
-      val make : ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      val make: ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -125,7 +125,7 @@ module rec Google : sig
     and EnumValueDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; number: int option; options: EnumValueOptions.t option }
-      val make : ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
+      val make: ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -134,7 +134,7 @@ module rec Google : sig
     and ServiceDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; method': MethodDescriptorProto.t list; options: ServiceOptions.t option }
-      val make : ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
+      val make: ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -143,7 +143,7 @@ module rec Google : sig
     and MethodDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; input_type: string option; output_type: string option; options: MethodOptions.t option; client_streaming: bool; server_streaming: bool }
-      val make : ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
+      val make: ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -157,8 +157,8 @@ module rec Google : sig
         val from_int_exn: int -> t
       end
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -166,8 +166,8 @@ module rec Google : sig
     end
     and MessageOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -187,8 +187,8 @@ module rec Google : sig
         val from_int_exn: int -> t
       end
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -196,8 +196,8 @@ module rec Google : sig
     end
     and OneofOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -205,8 +205,8 @@ module rec Google : sig
     end
     and EnumOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -214,8 +214,8 @@ module rec Google : sig
     end
     and EnumValueOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -223,8 +223,8 @@ module rec Google : sig
     end
     and ServiceOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -238,8 +238,8 @@ module rec Google : sig
         val from_int_exn: int -> t
       end
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -249,7 +249,7 @@ module rec Google : sig
       module rec NamePart : sig
         val name': unit -> string
         type t = { name_part: string; is_extension: bool }
-        val make : name_part:string -> is_extension:bool -> unit -> t
+        val make: name_part:string -> is_extension:bool -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -257,7 +257,7 @@ module rec Google : sig
       end
       val name': unit -> string
       type t = { name: NamePart.t list; identifier_value: string option; positive_int_value: int option; negative_int_value: int option; double_value: float option; string_value: bytes option; aggregate_value: string option }
-      val make : ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
+      val make: ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -267,7 +267,7 @@ module rec Google : sig
       module rec Location : sig
         val name': unit -> string
         type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
-        val make : ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
+        val make: ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -275,7 +275,7 @@ module rec Google : sig
       end
       val name': unit -> string
       type t = Location.t list
-      val make : ?location:Location.t list -> unit -> t
+      val make: ?location:Location.t list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -285,7 +285,7 @@ module rec Google : sig
       module rec Annotation : sig
         val name': unit -> string
         type t = { path: int list; source_file: string option; begin': int option; end': int option }
-        val make : ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
+        val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -293,7 +293,7 @@ module rec Google : sig
       end
       val name': unit -> string
       type t = Annotation.t list
-      val make : ?annotation:Annotation.t list -> unit -> t
+      val make: ?annotation:Annotation.t list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -305,7 +305,7 @@ end = struct
     module rec FileDescriptorSet : sig
       val name': unit -> string
       type t = FileDescriptorProto.t list
-      val make : ?file:FileDescriptorProto.t list -> unit -> t
+      val make: ?file:FileDescriptorProto.t list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -314,7 +314,7 @@ end = struct
     and FileDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; package: string option; dependency: string list; message_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; service: ServiceDescriptorProto.t list; extension: FieldDescriptorProto.t list; options: FileOptions.t option; source_code_info: SourceCodeInfo.t option; public_dependency: int list; weak_dependency: int list; syntax: string option }
-      val make : ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
+      val make: ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -324,7 +324,7 @@ end = struct
       module rec ExtensionRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
-        val make : ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
+        val make: ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -333,7 +333,7 @@ end = struct
       and ReservedRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option }
-        val make : ?start:int -> ?end':int -> unit -> t
+        val make: ?start:int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -341,7 +341,7 @@ end = struct
       end
       val name': unit -> string
       type t = { name: string option; field: FieldDescriptorProto.t list; nested_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; extension_range: ExtensionRange.t list; extension: FieldDescriptorProto.t list; options: MessageOptions.t option; oneof_decl: OneofDescriptorProto.t list; reserved_range: ReservedRange.t list; reserved_name: string list }
-      val make : ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      val make: ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -349,8 +349,8 @@ end = struct
     end
     and ExtensionRangeOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -371,7 +371,7 @@ end = struct
       end
       val name': unit -> string
       type t = { name: string option; extendee: string option; number: int option; label: Label.t option; type': Type.t option; type_name: string option; default_value: string option; options: FieldOptions.t option; oneof_index: int option; json_name: string option; proto3_optional: bool option }
-      val make : ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
+      val make: ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -380,7 +380,7 @@ end = struct
     and OneofDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; options: OneofOptions.t option }
-      val make : ?name:string -> ?options:OneofOptions.t -> unit -> t
+      val make: ?name:string -> ?options:OneofOptions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -390,7 +390,7 @@ end = struct
       module rec EnumReservedRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option }
-        val make : ?start:int -> ?end':int -> unit -> t
+        val make: ?start:int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -398,7 +398,7 @@ end = struct
       end
       val name': unit -> string
       type t = { name: string option; value: EnumValueDescriptorProto.t list; options: EnumOptions.t option; reserved_range: EnumReservedRange.t list; reserved_name: string list }
-      val make : ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      val make: ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -407,7 +407,7 @@ end = struct
     and EnumValueDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; number: int option; options: EnumValueOptions.t option }
-      val make : ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
+      val make: ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -416,7 +416,7 @@ end = struct
     and ServiceDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; method': MethodDescriptorProto.t list; options: ServiceOptions.t option }
-      val make : ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
+      val make: ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -425,7 +425,7 @@ end = struct
     and MethodDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; input_type: string option; output_type: string option; options: MethodOptions.t option; client_streaming: bool; server_streaming: bool }
-      val make : ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
+      val make: ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -439,8 +439,8 @@ end = struct
         val from_int_exn: int -> t
       end
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -448,8 +448,8 @@ end = struct
     end
     and MessageOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -469,8 +469,8 @@ end = struct
         val from_int_exn: int -> t
       end
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -478,8 +478,8 @@ end = struct
     end
     and OneofOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -487,8 +487,8 @@ end = struct
     end
     and EnumOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -496,8 +496,8 @@ end = struct
     end
     and EnumValueOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -505,8 +505,8 @@ end = struct
     end
     and ServiceOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -520,8 +520,8 @@ end = struct
         val from_int_exn: int -> t
       end
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -531,7 +531,7 @@ end = struct
       module rec NamePart : sig
         val name': unit -> string
         type t = { name_part: string; is_extension: bool }
-        val make : name_part:string -> is_extension:bool -> unit -> t
+        val make: name_part:string -> is_extension:bool -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -539,7 +539,7 @@ end = struct
       end
       val name': unit -> string
       type t = { name: NamePart.t list; identifier_value: string option; positive_int_value: int option; negative_int_value: int option; double_value: float option; string_value: bytes option; aggregate_value: string option }
-      val make : ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
+      val make: ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -549,7 +549,7 @@ end = struct
       module rec Location : sig
         val name': unit -> string
         type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
-        val make : ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
+        val make: ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -557,7 +557,7 @@ end = struct
       end
       val name': unit -> string
       type t = Location.t list
-      val make : ?location:Location.t list -> unit -> t
+      val make: ?location:Location.t list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -567,7 +567,7 @@ end = struct
       module rec Annotation : sig
         val name': unit -> string
         type t = { path: int list; source_file: string option; begin': int option; end': int option }
-        val make : ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
+        val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -575,7 +575,7 @@ end = struct
       end
       val name': unit -> string
       type t = Annotation.t list
-      val make : ?annotation:Annotation.t list -> unit -> t
+      val make: ?annotation:Annotation.t list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -585,7 +585,7 @@ end = struct
     module rec FileDescriptorSet : sig
       val name': unit -> string
       type t = FileDescriptorProto.t list
-      val make : ?file:FileDescriptorProto.t list -> unit -> t
+      val make: ?file:FileDescriptorProto.t list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -595,25 +595,21 @@ end = struct
       type t = FileDescriptorProto.t list
       let make ?(file = []) () = file
       let to_proto' =
-        let apply = fun ~f:f' writer file -> f' [] writer file in
         let spec = Runtime'.Serialize.C.( repeated (1, (message (fun t -> FileDescriptorProto.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        serialize
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun file _extensions -> file in
+        let constructor = fun file -> file in
         let spec = Runtime'.Deserialize.C.( repeated (1, (message (fun t -> FileDescriptorProto.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and FileDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; package: string option; dependency: string list; message_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; service: ServiceDescriptorProto.t list; extension: FieldDescriptorProto.t list; options: FileOptions.t option; source_code_info: SourceCodeInfo.t option; public_dependency: int list; weak_dependency: int list; syntax: string option }
-      val make : ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
+      val make: ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -623,26 +619,22 @@ end = struct
       type t = { name: string option; package: string option; dependency: string list; message_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; service: ServiceDescriptorProto.t list; extension: FieldDescriptorProto.t list; options: FileOptions.t option; source_code_info: SourceCodeInfo.t option; public_dependency: int list; weak_dependency: int list; syntax: string option }
       let make ?name ?package ?(dependency = []) ?(message_type = []) ?(enum_type = []) ?(service = []) ?(extension = []) ?options ?source_code_info ?(public_dependency = []) ?(weak_dependency = []) ?syntax () = { name; package; dependency; message_type; enum_type; service; extension; options; source_code_info; public_dependency; weak_dependency; syntax }
       let to_proto' =
-        let apply = fun ~f:f' writer { name; package; dependency; message_type; enum_type; service; extension; options; source_code_info; public_dependency; weak_dependency; syntax } -> f' [] writer name package dependency message_type enum_type service extension options source_code_info public_dependency weak_dependency syntax in
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: repeated (3, string, not_packed) ^:: repeated (4, (message (fun t -> DescriptorProto.to_proto' t)), not_packed) ^:: repeated (5, (message (fun t -> EnumDescriptorProto.to_proto' t)), not_packed) ^:: repeated (6, (message (fun t -> ServiceDescriptorProto.to_proto' t)), not_packed) ^:: repeated (7, (message (fun t -> FieldDescriptorProto.to_proto' t)), not_packed) ^:: basic_opt (8, (message (fun t -> FileOptions.to_proto' t))) ^:: basic_opt (9, (message (fun t -> SourceCodeInfo.to_proto' t))) ^:: repeated (10, int32_int, not_packed) ^:: repeated (11, int32_int, not_packed) ^:: basic_opt (12, string) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { name; package; dependency; message_type; enum_type; service; extension; options; source_code_info; public_dependency; weak_dependency; syntax } -> serialize writer name package dependency message_type enum_type service extension options source_code_info public_dependency weak_dependency syntax
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun name package dependency message_type enum_type service extension options source_code_info public_dependency weak_dependency syntax _extensions -> { name; package; dependency; message_type; enum_type; service; extension; options; source_code_info; public_dependency; weak_dependency; syntax } in
+        let constructor = fun name package dependency message_type enum_type service extension options source_code_info public_dependency weak_dependency syntax -> { name; package; dependency; message_type; enum_type; service; extension; options; source_code_info; public_dependency; weak_dependency; syntax } in
         let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: repeated (3, string, not_packed) ^:: repeated (4, (message (fun t -> DescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (5, (message (fun t -> EnumDescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (6, (message (fun t -> ServiceDescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (7, (message (fun t -> FieldDescriptorProto.from_proto_exn t)), not_packed) ^:: basic_opt (8, (message (fun t -> FileOptions.from_proto_exn t))) ^:: basic_opt (9, (message (fun t -> SourceCodeInfo.from_proto_exn t))) ^:: repeated (10, int32_int, not_packed) ^:: repeated (11, int32_int, not_packed) ^:: basic_opt (12, string) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and DescriptorProto : sig
       module rec ExtensionRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
-        val make : ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
+        val make: ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -651,7 +643,7 @@ end = struct
       and ReservedRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option }
-        val make : ?start:int -> ?end':int -> unit -> t
+        val make: ?start:int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -659,7 +651,7 @@ end = struct
       end
       val name': unit -> string
       type t = { name: string option; field: FieldDescriptorProto.t list; nested_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; extension_range: ExtensionRange.t list; extension: FieldDescriptorProto.t list; options: MessageOptions.t option; oneof_decl: OneofDescriptorProto.t list; reserved_range: ReservedRange.t list; reserved_name: string list }
-      val make : ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      val make: ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -668,7 +660,7 @@ end = struct
       module rec ExtensionRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
-        val make : ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
+        val make: ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -678,25 +670,21 @@ end = struct
         type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
         let make ?start ?end' ?options () = { start; end'; options }
         let to_proto' =
-          let apply = fun ~f:f' writer { start; end'; options } -> f' [] writer start end' options in
           let spec = Runtime'.Serialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, (message (fun t -> ExtensionRangeOptions.to_proto' t))) ^:: nil ) in
-          let serialize = Runtime'.Serialize.serialize [] spec in
-          fun writer t -> apply ~f:serialize writer t
+          let serialize = Runtime'.Serialize.serialize spec in
+          fun writer { start; end'; options } -> serialize writer start end' options
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
         let from_proto_exn =
-          let constructor = fun start end' options _extensions -> { start; end'; options } in
+          let constructor = fun start end' options -> { start; end'; options } in
           let spec = Runtime'.Deserialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, (message (fun t -> ExtensionRangeOptions.from_proto_exn t))) ^:: nil ) in
-          let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-          fun writer -> deserialize writer
-          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+          Runtime'.Deserialize.deserialize spec constructor
+        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       and ReservedRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option }
-        val make : ?start:int -> ?end':int -> unit -> t
+        val make: ?start:int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -706,67 +694,55 @@ end = struct
         type t = { start: int option; end': int option }
         let make ?start ?end' () = { start; end' }
         let to_proto' =
-          let apply = fun ~f:f' writer { start; end' } -> f' [] writer start end' in
           let spec = Runtime'.Serialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: nil ) in
-          let serialize = Runtime'.Serialize.serialize [] spec in
-          fun writer t -> apply ~f:serialize writer t
+          let serialize = Runtime'.Serialize.serialize spec in
+          fun writer { start; end' } -> serialize writer start end'
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
         let from_proto_exn =
-          let constructor = fun start end' _extensions -> { start; end' } in
+          let constructor = fun start end' -> { start; end' } in
           let spec = Runtime'.Deserialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: nil ) in
-          let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-          fun writer -> deserialize writer
-          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+          Runtime'.Deserialize.deserialize spec constructor
+        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       let name' () = "descriptor.google.protobuf.DescriptorProto"
       type t = { name: string option; field: FieldDescriptorProto.t list; nested_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; extension_range: ExtensionRange.t list; extension: FieldDescriptorProto.t list; options: MessageOptions.t option; oneof_decl: OneofDescriptorProto.t list; reserved_range: ReservedRange.t list; reserved_name: string list }
       let make ?name ?(field = []) ?(nested_type = []) ?(enum_type = []) ?(extension_range = []) ?(extension = []) ?options ?(oneof_decl = []) ?(reserved_range = []) ?(reserved_name = []) () = { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name }
       let to_proto' =
-        let apply = fun ~f:f' writer { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name } -> f' [] writer name field nested_type enum_type extension_range extension options oneof_decl reserved_range reserved_name in
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: repeated (2, (message (fun t -> FieldDescriptorProto.to_proto' t)), not_packed) ^:: repeated (3, (message (fun t -> DescriptorProto.to_proto' t)), not_packed) ^:: repeated (4, (message (fun t -> EnumDescriptorProto.to_proto' t)), not_packed) ^:: repeated (5, (message (fun t -> ExtensionRange.to_proto' t)), not_packed) ^:: repeated (6, (message (fun t -> FieldDescriptorProto.to_proto' t)), not_packed) ^:: basic_opt (7, (message (fun t -> MessageOptions.to_proto' t))) ^:: repeated (8, (message (fun t -> OneofDescriptorProto.to_proto' t)), not_packed) ^:: repeated (9, (message (fun t -> ReservedRange.to_proto' t)), not_packed) ^:: repeated (10, string, not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name } -> serialize writer name field nested_type enum_type extension_range extension options oneof_decl reserved_range reserved_name
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun name field nested_type enum_type extension_range extension options oneof_decl reserved_range reserved_name _extensions -> { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name } in
+        let constructor = fun name field nested_type enum_type extension_range extension options oneof_decl reserved_range reserved_name -> { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name } in
         let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: repeated (2, (message (fun t -> FieldDescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (3, (message (fun t -> DescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (4, (message (fun t -> EnumDescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (5, (message (fun t -> ExtensionRange.from_proto_exn t)), not_packed) ^:: repeated (6, (message (fun t -> FieldDescriptorProto.from_proto_exn t)), not_packed) ^:: basic_opt (7, (message (fun t -> MessageOptions.from_proto_exn t))) ^:: repeated (8, (message (fun t -> OneofDescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (9, (message (fun t -> ReservedRange.from_proto_exn t)), not_packed) ^:: repeated (10, string, not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and ExtensionRangeOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
     end = struct
       let name' () = "descriptor.google.protobuf.ExtensionRangeOptions"
-      type t = { extensions': Runtime'.Extensions.t; uninterpreted_option: UninterpretedOption.t list }
+      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { uninterpreted_option; extensions' }
       let to_proto' =
-        let apply = fun ~f:f' writer { uninterpreted_option; extensions' } -> f' extensions' writer uninterpreted_option in
-        let spec = Runtime'.Serialize.C.( repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [(1000, 536870912)] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let spec = Runtime'.Serialize.C.( repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { uninterpreted_option; extensions' } -> serialize writer uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
         let constructor = fun uninterpreted_option extensions' -> { uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [(1000, 536870912)] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        let spec = Runtime'.Deserialize.C.( repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and FieldDescriptorProto : sig
       module rec Type : sig
@@ -783,7 +759,7 @@ end = struct
       end
       val name': unit -> string
       type t = { name: string option; extendee: string option; number: int option; label: Label.t option; type': Type.t option; type_name: string option; default_value: string option; options: FieldOptions.t option; oneof_index: int option; json_name: string option; proto3_optional: bool option }
-      val make : ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
+      val make: ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -863,25 +839,21 @@ end = struct
       type t = { name: string option; extendee: string option; number: int option; label: Label.t option; type': Type.t option; type_name: string option; default_value: string option; options: FieldOptions.t option; oneof_index: int option; json_name: string option; proto3_optional: bool option }
       let make ?name ?extendee ?number ?label ?type' ?type_name ?default_value ?options ?oneof_index ?json_name ?proto3_optional () = { name; extendee; number; label; type'; type_name; default_value; options; oneof_index; json_name; proto3_optional }
       let to_proto' =
-        let apply = fun ~f:f' writer { name; extendee; number; label; type'; type_name; default_value; options; oneof_index; json_name; proto3_optional } -> f' [] writer name extendee number label type' type_name default_value options oneof_index json_name proto3_optional in
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, (enum Label.to_int)) ^:: basic_opt (5, (enum Type.to_int)) ^:: basic_opt (6, string) ^:: basic_opt (7, string) ^:: basic_opt (8, (message (fun t -> FieldOptions.to_proto' t))) ^:: basic_opt (9, int32_int) ^:: basic_opt (10, string) ^:: basic_opt (17, bool) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { name; extendee; number; label; type'; type_name; default_value; options; oneof_index; json_name; proto3_optional } -> serialize writer name extendee number label type' type_name default_value options oneof_index json_name proto3_optional
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun name extendee number label type' type_name default_value options oneof_index json_name proto3_optional _extensions -> { name; extendee; number; label; type'; type_name; default_value; options; oneof_index; json_name; proto3_optional } in
+        let constructor = fun name extendee number label type' type_name default_value options oneof_index json_name proto3_optional -> { name; extendee; number; label; type'; type_name; default_value; options; oneof_index; json_name; proto3_optional } in
         let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, (enum Label.from_int_exn)) ^:: basic_opt (5, (enum Type.from_int_exn)) ^:: basic_opt (6, string) ^:: basic_opt (7, string) ^:: basic_opt (8, (message (fun t -> FieldOptions.from_proto_exn t))) ^:: basic_opt (9, int32_int) ^:: basic_opt (10, string) ^:: basic_opt (17, bool) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and OneofDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; options: OneofOptions.t option }
-      val make : ?name:string -> ?options:OneofOptions.t -> unit -> t
+      val make: ?name:string -> ?options:OneofOptions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -891,26 +863,22 @@ end = struct
       type t = { name: string option; options: OneofOptions.t option }
       let make ?name ?options () = { name; options }
       let to_proto' =
-        let apply = fun ~f:f' writer { name; options } -> f' [] writer name options in
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, (message (fun t -> OneofOptions.to_proto' t))) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { name; options } -> serialize writer name options
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun name options _extensions -> { name; options } in
+        let constructor = fun name options -> { name; options } in
         let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, (message (fun t -> OneofOptions.from_proto_exn t))) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and EnumDescriptorProto : sig
       module rec EnumReservedRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option }
-        val make : ?start:int -> ?end':int -> unit -> t
+        val make: ?start:int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -918,7 +886,7 @@ end = struct
       end
       val name': unit -> string
       type t = { name: string option; value: EnumValueDescriptorProto.t list; options: EnumOptions.t option; reserved_range: EnumReservedRange.t list; reserved_name: string list }
-      val make : ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      val make: ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -927,7 +895,7 @@ end = struct
       module rec EnumReservedRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option }
-        val make : ?start:int -> ?end':int -> unit -> t
+        val make: ?start:int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -937,44 +905,36 @@ end = struct
         type t = { start: int option; end': int option }
         let make ?start ?end' () = { start; end' }
         let to_proto' =
-          let apply = fun ~f:f' writer { start; end' } -> f' [] writer start end' in
           let spec = Runtime'.Serialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: nil ) in
-          let serialize = Runtime'.Serialize.serialize [] spec in
-          fun writer t -> apply ~f:serialize writer t
+          let serialize = Runtime'.Serialize.serialize spec in
+          fun writer { start; end' } -> serialize writer start end'
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
         let from_proto_exn =
-          let constructor = fun start end' _extensions -> { start; end' } in
+          let constructor = fun start end' -> { start; end' } in
           let spec = Runtime'.Deserialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: nil ) in
-          let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-          fun writer -> deserialize writer
-          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+          Runtime'.Deserialize.deserialize spec constructor
+        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       let name' () = "descriptor.google.protobuf.EnumDescriptorProto"
       type t = { name: string option; value: EnumValueDescriptorProto.t list; options: EnumOptions.t option; reserved_range: EnumReservedRange.t list; reserved_name: string list }
       let make ?name ?(value = []) ?options ?(reserved_range = []) ?(reserved_name = []) () = { name; value; options; reserved_range; reserved_name }
       let to_proto' =
-        let apply = fun ~f:f' writer { name; value; options; reserved_range; reserved_name } -> f' [] writer name value options reserved_range reserved_name in
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: repeated (2, (message (fun t -> EnumValueDescriptorProto.to_proto' t)), not_packed) ^:: basic_opt (3, (message (fun t -> EnumOptions.to_proto' t))) ^:: repeated (4, (message (fun t -> EnumReservedRange.to_proto' t)), not_packed) ^:: repeated (5, string, not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { name; value; options; reserved_range; reserved_name } -> serialize writer name value options reserved_range reserved_name
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun name value options reserved_range reserved_name _extensions -> { name; value; options; reserved_range; reserved_name } in
+        let constructor = fun name value options reserved_range reserved_name -> { name; value; options; reserved_range; reserved_name } in
         let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: repeated (2, (message (fun t -> EnumValueDescriptorProto.from_proto_exn t)), not_packed) ^:: basic_opt (3, (message (fun t -> EnumOptions.from_proto_exn t))) ^:: repeated (4, (message (fun t -> EnumReservedRange.from_proto_exn t)), not_packed) ^:: repeated (5, string, not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and EnumValueDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; number: int option; options: EnumValueOptions.t option }
-      val make : ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
+      val make: ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -984,25 +944,21 @@ end = struct
       type t = { name: string option; number: int option; options: EnumValueOptions.t option }
       let make ?name ?number ?options () = { name; number; options }
       let to_proto' =
-        let apply = fun ~f:f' writer { name; number; options } -> f' [] writer name number options in
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, (message (fun t -> EnumValueOptions.to_proto' t))) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { name; number; options } -> serialize writer name number options
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun name number options _extensions -> { name; number; options } in
+        let constructor = fun name number options -> { name; number; options } in
         let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, (message (fun t -> EnumValueOptions.from_proto_exn t))) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and ServiceDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; method': MethodDescriptorProto.t list; options: ServiceOptions.t option }
-      val make : ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
+      val make: ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1012,25 +968,21 @@ end = struct
       type t = { name: string option; method': MethodDescriptorProto.t list; options: ServiceOptions.t option }
       let make ?name ?(method' = []) ?options () = { name; method'; options }
       let to_proto' =
-        let apply = fun ~f:f' writer { name; method'; options } -> f' [] writer name method' options in
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: repeated (2, (message (fun t -> MethodDescriptorProto.to_proto' t)), not_packed) ^:: basic_opt (3, (message (fun t -> ServiceOptions.to_proto' t))) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { name; method'; options } -> serialize writer name method' options
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun name method' options _extensions -> { name; method'; options } in
+        let constructor = fun name method' options -> { name; method'; options } in
         let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: repeated (2, (message (fun t -> MethodDescriptorProto.from_proto_exn t)), not_packed) ^:: basic_opt (3, (message (fun t -> ServiceOptions.from_proto_exn t))) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and MethodDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; input_type: string option; output_type: string option; options: MethodOptions.t option; client_streaming: bool; server_streaming: bool }
-      val make : ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
+      val make: ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1040,20 +992,16 @@ end = struct
       type t = { name: string option; input_type: string option; output_type: string option; options: MethodOptions.t option; client_streaming: bool; server_streaming: bool }
       let make ?name ?input_type ?output_type ?options ?(client_streaming = false) ?(server_streaming = false) () = { name; input_type; output_type; options; client_streaming; server_streaming }
       let to_proto' =
-        let apply = fun ~f:f' writer { name; input_type; output_type; options; client_streaming; server_streaming } -> f' [] writer name input_type output_type options client_streaming server_streaming in
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, string) ^:: basic_opt (4, (message (fun t -> MethodOptions.to_proto' t))) ^:: basic (5, bool, Some (false)) ^:: basic (6, bool, Some (false)) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { name; input_type; output_type; options; client_streaming; server_streaming } -> serialize writer name input_type output_type options client_streaming server_streaming
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun name input_type output_type options client_streaming server_streaming _extensions -> { name; input_type; output_type; options; client_streaming; server_streaming } in
+        let constructor = fun name input_type output_type options client_streaming server_streaming -> { name; input_type; output_type; options; client_streaming; server_streaming } in
         let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, string) ^:: basic_opt (4, (message (fun t -> MethodOptions.from_proto_exn t))) ^:: basic (5, bool, Some (false)) ^:: basic (6, bool, Some (false)) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and FileOptions : sig
       module rec OptimizeMode : sig
@@ -1063,8 +1011,8 @@ end = struct
         val from_int_exn: int -> t
       end
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1091,51 +1039,43 @@ end = struct
         let from_int e = Runtime'.Result.catch (fun () -> from_int_exn e)
       end
       let name' () = "descriptor.google.protobuf.FileOptions"
-      type t = { extensions': Runtime'.Extensions.t; java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list }
+      type t = { java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?java_package ?java_outer_classname ?(optimize_for = OptimizeMode.SPEED) ?(java_multiple_files = false) ?go_package ?(cc_generic_services = false) ?(java_generic_services = false) ?(py_generic_services = false) ?java_generate_equals_and_hash ?(deprecated = false) ?(java_string_check_utf8 = false) ?(cc_enable_arenas = true) ?objc_class_prefix ?csharp_namespace ?swift_prefix ?php_class_prefix ?php_namespace ?(php_generic_services = false) ?php_metadata_namespace ?ruby_package ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { java_package; java_outer_classname; optimize_for; java_multiple_files; go_package; cc_generic_services; java_generic_services; py_generic_services; java_generate_equals_and_hash; deprecated; java_string_check_utf8; cc_enable_arenas; objc_class_prefix; csharp_namespace; swift_prefix; php_class_prefix; php_namespace; php_generic_services; php_metadata_namespace; ruby_package; uninterpreted_option; extensions' }
       let to_proto' =
-        let apply = fun ~f:f' writer { java_package; java_outer_classname; optimize_for; java_multiple_files; go_package; cc_generic_services; java_generic_services; py_generic_services; java_generate_equals_and_hash; deprecated; java_string_check_utf8; cc_enable_arenas; objc_class_prefix; csharp_namespace; swift_prefix; php_class_prefix; php_namespace; php_generic_services; php_metadata_namespace; ruby_package; uninterpreted_option; extensions' } -> f' extensions' writer java_package java_outer_classname optimize_for java_multiple_files go_package cc_generic_services java_generic_services py_generic_services java_generate_equals_and_hash deprecated java_string_check_utf8 cc_enable_arenas objc_class_prefix csharp_namespace swift_prefix php_class_prefix php_namespace php_generic_services php_metadata_namespace ruby_package uninterpreted_option in
-        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (8, string) ^:: basic (9, (enum OptimizeMode.to_int), Some (OptimizeMode.SPEED)) ^:: basic (10, bool, Some (false)) ^:: basic_opt (11, string) ^:: basic (16, bool, Some (false)) ^:: basic (17, bool, Some (false)) ^:: basic (18, bool, Some (false)) ^:: basic_opt (20, bool) ^:: basic (23, bool, Some (false)) ^:: basic (27, bool, Some (false)) ^:: basic (31, bool, Some (true)) ^:: basic_opt (36, string) ^:: basic_opt (37, string) ^:: basic_opt (39, string) ^:: basic_opt (40, string) ^:: basic_opt (41, string) ^:: basic (42, bool, Some (false)) ^:: basic_opt (44, string) ^:: basic_opt (45, string) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [(1000, 536870912)] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (8, string) ^:: basic (9, (enum OptimizeMode.to_int), Some (OptimizeMode.SPEED)) ^:: basic (10, bool, Some (false)) ^:: basic_opt (11, string) ^:: basic (16, bool, Some (false)) ^:: basic (17, bool, Some (false)) ^:: basic (18, bool, Some (false)) ^:: basic_opt (20, bool) ^:: basic (23, bool, Some (false)) ^:: basic (27, bool, Some (false)) ^:: basic (31, bool, Some (true)) ^:: basic_opt (36, string) ^:: basic_opt (37, string) ^:: basic_opt (39, string) ^:: basic_opt (40, string) ^:: basic_opt (41, string) ^:: basic (42, bool, Some (false)) ^:: basic_opt (44, string) ^:: basic_opt (45, string) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { java_package; java_outer_classname; optimize_for; java_multiple_files; go_package; cc_generic_services; java_generic_services; py_generic_services; java_generate_equals_and_hash; deprecated; java_string_check_utf8; cc_enable_arenas; objc_class_prefix; csharp_namespace; swift_prefix; php_class_prefix; php_namespace; php_generic_services; php_metadata_namespace; ruby_package; uninterpreted_option; extensions' } -> serialize writer java_package java_outer_classname optimize_for java_multiple_files go_package cc_generic_services java_generic_services py_generic_services java_generate_equals_and_hash deprecated java_string_check_utf8 cc_enable_arenas objc_class_prefix csharp_namespace swift_prefix php_class_prefix php_namespace php_generic_services php_metadata_namespace ruby_package uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
         let constructor = fun java_package java_outer_classname optimize_for java_multiple_files go_package cc_generic_services java_generic_services py_generic_services java_generate_equals_and_hash deprecated java_string_check_utf8 cc_enable_arenas objc_class_prefix csharp_namespace swift_prefix php_class_prefix php_namespace php_generic_services php_metadata_namespace ruby_package uninterpreted_option extensions' -> { java_package; java_outer_classname; optimize_for; java_multiple_files; go_package; cc_generic_services; java_generic_services; py_generic_services; java_generate_equals_and_hash; deprecated; java_string_check_utf8; cc_enable_arenas; objc_class_prefix; csharp_namespace; swift_prefix; php_class_prefix; php_namespace; php_generic_services; php_metadata_namespace; ruby_package; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (8, string) ^:: basic (9, (enum OptimizeMode.from_int_exn), Some (OptimizeMode.SPEED)) ^:: basic (10, bool, Some (false)) ^:: basic_opt (11, string) ^:: basic (16, bool, Some (false)) ^:: basic (17, bool, Some (false)) ^:: basic (18, bool, Some (false)) ^:: basic_opt (20, bool) ^:: basic (23, bool, Some (false)) ^:: basic (27, bool, Some (false)) ^:: basic (31, bool, Some (true)) ^:: basic_opt (36, string) ^:: basic_opt (37, string) ^:: basic_opt (39, string) ^:: basic_opt (40, string) ^:: basic_opt (41, string) ^:: basic (42, bool, Some (false)) ^:: basic_opt (44, string) ^:: basic_opt (45, string) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [(1000, 536870912)] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (8, string) ^:: basic (9, (enum OptimizeMode.from_int_exn), Some (OptimizeMode.SPEED)) ^:: basic (10, bool, Some (false)) ^:: basic_opt (11, string) ^:: basic (16, bool, Some (false)) ^:: basic (17, bool, Some (false)) ^:: basic (18, bool, Some (false)) ^:: basic_opt (20, bool) ^:: basic (23, bool, Some (false)) ^:: basic (27, bool, Some (false)) ^:: basic (31, bool, Some (true)) ^:: basic_opt (36, string) ^:: basic_opt (37, string) ^:: basic_opt (39, string) ^:: basic_opt (40, string) ^:: basic_opt (41, string) ^:: basic (42, bool, Some (false)) ^:: basic_opt (44, string) ^:: basic_opt (45, string) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and MessageOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
     end = struct
       let name' () = "descriptor.google.protobuf.MessageOptions"
-      type t = { extensions': Runtime'.Extensions.t; message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list }
+      type t = { message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(message_set_wire_format = false) ?(no_standard_descriptor_accessor = false) ?(deprecated = false) ?map_entry ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { message_set_wire_format; no_standard_descriptor_accessor; deprecated; map_entry; uninterpreted_option; extensions' }
       let to_proto' =
-        let apply = fun ~f:f' writer { message_set_wire_format; no_standard_descriptor_accessor; deprecated; map_entry; uninterpreted_option; extensions' } -> f' extensions' writer message_set_wire_format no_standard_descriptor_accessor deprecated map_entry uninterpreted_option in
-        let spec = Runtime'.Serialize.C.( basic (1, bool, Some (false)) ^:: basic (2, bool, Some (false)) ^:: basic (3, bool, Some (false)) ^:: basic_opt (7, bool) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [(1000, 536870912)] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let spec = Runtime'.Serialize.C.( basic (1, bool, Some (false)) ^:: basic (2, bool, Some (false)) ^:: basic (3, bool, Some (false)) ^:: basic_opt (7, bool) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { message_set_wire_format; no_standard_descriptor_accessor; deprecated; map_entry; uninterpreted_option; extensions' } -> serialize writer message_set_wire_format no_standard_descriptor_accessor deprecated map_entry uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
         let constructor = fun message_set_wire_format no_standard_descriptor_accessor deprecated map_entry uninterpreted_option extensions' -> { message_set_wire_format; no_standard_descriptor_accessor; deprecated; map_entry; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ^:: basic (2, bool, Some (false)) ^:: basic (3, bool, Some (false)) ^:: basic_opt (7, bool) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [(1000, 536870912)] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        let spec = Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ^:: basic (2, bool, Some (false)) ^:: basic (3, bool, Some (false)) ^:: basic_opt (7, bool) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and FieldOptions : sig
       module rec CType : sig
@@ -1151,8 +1091,8 @@ end = struct
         val from_int_exn: int -> t
       end
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1199,135 +1139,115 @@ end = struct
         let from_int e = Runtime'.Result.catch (fun () -> from_int_exn e)
       end
       let name' () = "descriptor.google.protobuf.FieldOptions"
-      type t = { extensions': Runtime'.Extensions.t; ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list }
+      type t = { ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(ctype = CType.STRING) ?packed ?(deprecated = false) ?(lazy' = false) ?(jstype = JSType.JS_NORMAL) ?(weak = false) ?(unverified_lazy = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { ctype; packed; deprecated; lazy'; jstype; weak; unverified_lazy; uninterpreted_option; extensions' }
       let to_proto' =
-        let apply = fun ~f:f' writer { ctype; packed; deprecated; lazy'; jstype; weak; unverified_lazy; uninterpreted_option; extensions' } -> f' extensions' writer ctype packed deprecated lazy' jstype weak unverified_lazy uninterpreted_option in
-        let spec = Runtime'.Serialize.C.( basic (1, (enum CType.to_int), Some (CType.STRING)) ^:: basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: basic (5, bool, Some (false)) ^:: basic (6, (enum JSType.to_int), Some (JSType.JS_NORMAL)) ^:: basic (10, bool, Some (false)) ^:: basic (15, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [(1000, 536870912)] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let spec = Runtime'.Serialize.C.( basic (1, (enum CType.to_int), Some (CType.STRING)) ^:: basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: basic (5, bool, Some (false)) ^:: basic (6, (enum JSType.to_int), Some (JSType.JS_NORMAL)) ^:: basic (10, bool, Some (false)) ^:: basic (15, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { ctype; packed; deprecated; lazy'; jstype; weak; unverified_lazy; uninterpreted_option; extensions' } -> serialize writer ctype packed deprecated lazy' jstype weak unverified_lazy uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
         let constructor = fun ctype packed deprecated lazy' jstype weak unverified_lazy uninterpreted_option extensions' -> { ctype; packed; deprecated; lazy'; jstype; weak; unverified_lazy; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (1, (enum CType.from_int_exn), Some (CType.STRING)) ^:: basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: basic (5, bool, Some (false)) ^:: basic (6, (enum JSType.from_int_exn), Some (JSType.JS_NORMAL)) ^:: basic (10, bool, Some (false)) ^:: basic (15, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [(1000, 536870912)] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        let spec = Runtime'.Deserialize.C.( basic (1, (enum CType.from_int_exn), Some (CType.STRING)) ^:: basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: basic (5, bool, Some (false)) ^:: basic (6, (enum JSType.from_int_exn), Some (JSType.JS_NORMAL)) ^:: basic (10, bool, Some (false)) ^:: basic (15, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and OneofOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
     end = struct
       let name' () = "descriptor.google.protobuf.OneofOptions"
-      type t = { extensions': Runtime'.Extensions.t; uninterpreted_option: UninterpretedOption.t list }
+      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { uninterpreted_option; extensions' }
       let to_proto' =
-        let apply = fun ~f:f' writer { uninterpreted_option; extensions' } -> f' extensions' writer uninterpreted_option in
-        let spec = Runtime'.Serialize.C.( repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [(1000, 536870912)] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let spec = Runtime'.Serialize.C.( repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { uninterpreted_option; extensions' } -> serialize writer uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
         let constructor = fun uninterpreted_option extensions' -> { uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [(1000, 536870912)] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        let spec = Runtime'.Deserialize.C.( repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and EnumOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
     end = struct
       let name' () = "descriptor.google.protobuf.EnumOptions"
-      type t = { extensions': Runtime'.Extensions.t; allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
+      type t = { allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?allow_alias ?(deprecated = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { allow_alias; deprecated; uninterpreted_option; extensions' }
       let to_proto' =
-        let apply = fun ~f:f' writer { allow_alias; deprecated; uninterpreted_option; extensions' } -> f' extensions' writer allow_alias deprecated uninterpreted_option in
-        let spec = Runtime'.Serialize.C.( basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [(1000, 536870912)] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let spec = Runtime'.Serialize.C.( basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { allow_alias; deprecated; uninterpreted_option; extensions' } -> serialize writer allow_alias deprecated uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
         let constructor = fun allow_alias deprecated uninterpreted_option extensions' -> { allow_alias; deprecated; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [(1000, 536870912)] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        let spec = Runtime'.Deserialize.C.( basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and EnumValueOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
     end = struct
       let name' () = "descriptor.google.protobuf.EnumValueOptions"
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
+      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(deprecated = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { deprecated; uninterpreted_option; extensions' }
       let to_proto' =
-        let apply = fun ~f:f' writer { deprecated; uninterpreted_option; extensions' } -> f' extensions' writer deprecated uninterpreted_option in
-        let spec = Runtime'.Serialize.C.( basic (1, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [(1000, 536870912)] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let spec = Runtime'.Serialize.C.( basic (1, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { deprecated; uninterpreted_option; extensions' } -> serialize writer deprecated uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
         let constructor = fun deprecated uninterpreted_option extensions' -> { deprecated; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [(1000, 536870912)] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        let spec = Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and ServiceOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
     end = struct
       let name' () = "descriptor.google.protobuf.ServiceOptions"
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
+      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(deprecated = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { deprecated; uninterpreted_option; extensions' }
       let to_proto' =
-        let apply = fun ~f:f' writer { deprecated; uninterpreted_option; extensions' } -> f' extensions' writer deprecated uninterpreted_option in
-        let spec = Runtime'.Serialize.C.( basic (33, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [(1000, 536870912)] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let spec = Runtime'.Serialize.C.( basic (33, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { deprecated; uninterpreted_option; extensions' } -> serialize writer deprecated uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
         let constructor = fun deprecated uninterpreted_option extensions' -> { deprecated; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (33, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [(1000, 536870912)] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        let spec = Runtime'.Deserialize.C.( basic (33, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and MethodOptions : sig
       module rec IdempotencyLevel : sig
@@ -1337,8 +1257,8 @@ end = struct
         val from_int_exn: int -> t
       end
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1365,29 +1285,25 @@ end = struct
         let from_int e = Runtime'.Result.catch (fun () -> from_int_exn e)
       end
       let name' () = "descriptor.google.protobuf.MethodOptions"
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list }
+      type t = { deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(deprecated = false) ?(idempotency_level = IdempotencyLevel.IDEMPOTENCY_UNKNOWN) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { deprecated; idempotency_level; uninterpreted_option; extensions' }
       let to_proto' =
-        let apply = fun ~f:f' writer { deprecated; idempotency_level; uninterpreted_option; extensions' } -> f' extensions' writer deprecated idempotency_level uninterpreted_option in
-        let spec = Runtime'.Serialize.C.( basic (33, bool, Some (false)) ^:: basic (34, (enum IdempotencyLevel.to_int), Some (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [(1000, 536870912)] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let spec = Runtime'.Serialize.C.( basic (33, bool, Some (false)) ^:: basic (34, (enum IdempotencyLevel.to_int), Some (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { deprecated; idempotency_level; uninterpreted_option; extensions' } -> serialize writer deprecated idempotency_level uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
         let constructor = fun deprecated idempotency_level uninterpreted_option extensions' -> { deprecated; idempotency_level; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (33, bool, Some (false)) ^:: basic (34, (enum IdempotencyLevel.from_int_exn), Some (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [(1000, 536870912)] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        let spec = Runtime'.Deserialize.C.( basic (33, bool, Some (false)) ^:: basic (34, (enum IdempotencyLevel.from_int_exn), Some (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and UninterpretedOption : sig
       module rec NamePart : sig
         val name': unit -> string
         type t = { name_part: string; is_extension: bool }
-        val make : name_part:string -> is_extension:bool -> unit -> t
+        val make: name_part:string -> is_extension:bool -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1395,7 +1311,7 @@ end = struct
       end
       val name': unit -> string
       type t = { name: NamePart.t list; identifier_value: string option; positive_int_value: int option; negative_int_value: int option; double_value: float option; string_value: bytes option; aggregate_value: string option }
-      val make : ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
+      val make: ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1404,7 +1320,7 @@ end = struct
       module rec NamePart : sig
         val name': unit -> string
         type t = { name_part: string; is_extension: bool }
-        val make : name_part:string -> is_extension:bool -> unit -> t
+        val make: name_part:string -> is_extension:bool -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1414,45 +1330,37 @@ end = struct
         type t = { name_part: string; is_extension: bool }
         let make ~name_part ~is_extension () = { name_part; is_extension }
         let to_proto' =
-          let apply = fun ~f:f' writer { name_part; is_extension } -> f' [] writer name_part is_extension in
           let spec = Runtime'.Serialize.C.( basic (1, string, None) ^:: basic (2, bool, None) ^:: nil ) in
-          let serialize = Runtime'.Serialize.serialize [] spec in
-          fun writer t -> apply ~f:serialize writer t
+          let serialize = Runtime'.Serialize.serialize spec in
+          fun writer { name_part; is_extension } -> serialize writer name_part is_extension
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
         let from_proto_exn =
-          let constructor = fun name_part is_extension _extensions -> { name_part; is_extension } in
+          let constructor = fun name_part is_extension -> { name_part; is_extension } in
           let spec = Runtime'.Deserialize.C.( basic (1, string, None) ^:: basic (2, bool, None) ^:: nil ) in
-          let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-          fun writer -> deserialize writer
-          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+          Runtime'.Deserialize.deserialize spec constructor
+        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       let name' () = "descriptor.google.protobuf.UninterpretedOption"
       type t = { name: NamePart.t list; identifier_value: string option; positive_int_value: int option; negative_int_value: int option; double_value: float option; string_value: bytes option; aggregate_value: string option }
       let make ?(name = []) ?identifier_value ?positive_int_value ?negative_int_value ?double_value ?string_value ?aggregate_value () = { name; identifier_value; positive_int_value; negative_int_value; double_value; string_value; aggregate_value }
       let to_proto' =
-        let apply = fun ~f:f' writer { name; identifier_value; positive_int_value; negative_int_value; double_value; string_value; aggregate_value } -> f' [] writer name identifier_value positive_int_value negative_int_value double_value string_value aggregate_value in
         let spec = Runtime'.Serialize.C.( repeated (2, (message (fun t -> NamePart.to_proto' t)), not_packed) ^:: basic_opt (3, string) ^:: basic_opt (4, uint64_int) ^:: basic_opt (5, int64_int) ^:: basic_opt (6, double) ^:: basic_opt (7, bytes) ^:: basic_opt (8, string) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { name; identifier_value; positive_int_value; negative_int_value; double_value; string_value; aggregate_value } -> serialize writer name identifier_value positive_int_value negative_int_value double_value string_value aggregate_value
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun name identifier_value positive_int_value negative_int_value double_value string_value aggregate_value _extensions -> { name; identifier_value; positive_int_value; negative_int_value; double_value; string_value; aggregate_value } in
+        let constructor = fun name identifier_value positive_int_value negative_int_value double_value string_value aggregate_value -> { name; identifier_value; positive_int_value; negative_int_value; double_value; string_value; aggregate_value } in
         let spec = Runtime'.Deserialize.C.( repeated (2, (message (fun t -> NamePart.from_proto_exn t)), not_packed) ^:: basic_opt (3, string) ^:: basic_opt (4, uint64_int) ^:: basic_opt (5, int64_int) ^:: basic_opt (6, double) ^:: basic_opt (7, bytes) ^:: basic_opt (8, string) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and SourceCodeInfo : sig
       module rec Location : sig
         val name': unit -> string
         type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
-        val make : ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
+        val make: ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1460,7 +1368,7 @@ end = struct
       end
       val name': unit -> string
       type t = Location.t list
-      val make : ?location:Location.t list -> unit -> t
+      val make: ?location:Location.t list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1469,7 +1377,7 @@ end = struct
       module rec Location : sig
         val name': unit -> string
         type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
-        val make : ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
+        val make: ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1479,45 +1387,37 @@ end = struct
         type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
         let make ?(path = []) ?(span = []) ?leading_comments ?trailing_comments ?(leading_detached_comments = []) () = { path; span; leading_comments; trailing_comments; leading_detached_comments }
         let to_proto' =
-          let apply = fun ~f:f' writer { path; span; leading_comments; trailing_comments; leading_detached_comments } -> f' [] writer path span leading_comments trailing_comments leading_detached_comments in
           let spec = Runtime'.Serialize.C.( repeated (1, int32_int, packed) ^:: repeated (2, int32_int, packed) ^:: basic_opt (3, string) ^:: basic_opt (4, string) ^:: repeated (6, string, not_packed) ^:: nil ) in
-          let serialize = Runtime'.Serialize.serialize [] spec in
-          fun writer t -> apply ~f:serialize writer t
+          let serialize = Runtime'.Serialize.serialize spec in
+          fun writer { path; span; leading_comments; trailing_comments; leading_detached_comments } -> serialize writer path span leading_comments trailing_comments leading_detached_comments
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
         let from_proto_exn =
-          let constructor = fun path span leading_comments trailing_comments leading_detached_comments _extensions -> { path; span; leading_comments; trailing_comments; leading_detached_comments } in
+          let constructor = fun path span leading_comments trailing_comments leading_detached_comments -> { path; span; leading_comments; trailing_comments; leading_detached_comments } in
           let spec = Runtime'.Deserialize.C.( repeated (1, int32_int, packed) ^:: repeated (2, int32_int, packed) ^:: basic_opt (3, string) ^:: basic_opt (4, string) ^:: repeated (6, string, not_packed) ^:: nil ) in
-          let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-          fun writer -> deserialize writer
-          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+          Runtime'.Deserialize.deserialize spec constructor
+        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       let name' () = "descriptor.google.protobuf.SourceCodeInfo"
       type t = Location.t list
       let make ?(location = []) () = location
       let to_proto' =
-        let apply = fun ~f:f' writer location -> f' [] writer location in
         let spec = Runtime'.Serialize.C.( repeated (1, (message (fun t -> Location.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        serialize
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun location _extensions -> location in
+        let constructor = fun location -> location in
         let spec = Runtime'.Deserialize.C.( repeated (1, (message (fun t -> Location.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and GeneratedCodeInfo : sig
       module rec Annotation : sig
         val name': unit -> string
         type t = { path: int list; source_file: string option; begin': int option; end': int option }
-        val make : ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
+        val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1525,7 +1425,7 @@ end = struct
       end
       val name': unit -> string
       type t = Annotation.t list
-      val make : ?annotation:Annotation.t list -> unit -> t
+      val make: ?annotation:Annotation.t list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1534,7 +1434,7 @@ end = struct
       module rec Annotation : sig
         val name': unit -> string
         type t = { path: int list; source_file: string option; begin': int option; end': int option }
-        val make : ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
+        val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1544,39 +1444,31 @@ end = struct
         type t = { path: int list; source_file: string option; begin': int option; end': int option }
         let make ?(path = []) ?source_file ?begin' ?end' () = { path; source_file; begin'; end' }
         let to_proto' =
-          let apply = fun ~f:f' writer { path; source_file; begin'; end' } -> f' [] writer path source_file begin' end' in
           let spec = Runtime'.Serialize.C.( repeated (1, int32_int, packed) ^:: basic_opt (2, string) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, int32_int) ^:: nil ) in
-          let serialize = Runtime'.Serialize.serialize [] spec in
-          fun writer t -> apply ~f:serialize writer t
+          let serialize = Runtime'.Serialize.serialize spec in
+          fun writer { path; source_file; begin'; end' } -> serialize writer path source_file begin' end'
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
         let from_proto_exn =
-          let constructor = fun path source_file begin' end' _extensions -> { path; source_file; begin'; end' } in
+          let constructor = fun path source_file begin' end' -> { path; source_file; begin'; end' } in
           let spec = Runtime'.Deserialize.C.( repeated (1, int32_int, packed) ^:: basic_opt (2, string) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, int32_int) ^:: nil ) in
-          let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-          fun writer -> deserialize writer
-          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+          Runtime'.Deserialize.deserialize spec constructor
+        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       let name' () = "descriptor.google.protobuf.GeneratedCodeInfo"
       type t = Annotation.t list
       let make ?(annotation = []) () = annotation
       let to_proto' =
-        let apply = fun ~f:f' writer annotation -> f' [] writer annotation in
         let spec = Runtime'.Serialize.C.( repeated (1, (message (fun t -> Annotation.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        serialize
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun annotation _extensions -> annotation in
+        let constructor = fun annotation -> annotation in
         let spec = Runtime'.Deserialize.C.( repeated (1, (message (fun t -> Annotation.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
   end
 end

--- a/src/spec/options.ml
+++ b/src/spec/options.ml
@@ -26,7 +26,7 @@ end
 module rec Options : sig
   val name': unit -> string
   type t = bool
-  val make : ?mangle_names:bool -> unit -> t
+  val make: ?mangle_names:bool -> unit -> t
   val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
   val to_proto: t -> Runtime'.Writer.t
   val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -36,20 +36,16 @@ end = struct
   type t = bool
   let make ?(mangle_names = false) () = mangle_names
   let to_proto' =
-    let apply = fun ~f:f' writer mangle_names -> f' [] writer mangle_names in
     let spec = Runtime'.Serialize.C.( basic (1, bool, Some (false)) ^:: nil ) in
-    let serialize = Runtime'.Serialize.serialize [] spec in
-    fun writer t -> apply ~f:serialize writer t
+    let serialize = Runtime'.Serialize.serialize spec in
+    serialize
 
   let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
   let from_proto_exn =
-    let constructor = fun mangle_names _extensions -> mangle_names in
+    let constructor = fun mangle_names -> mangle_names in
     let spec = Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ^:: nil ) in
-    let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-    fun writer -> deserialize writer
-    let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+    Runtime'.Deserialize.deserialize spec constructor
+  let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
 end
 and Ocaml_options : sig
   type t = Options.t option
@@ -62,6 +58,6 @@ end = struct
   let get extendee = Runtime'.Result.catch (fun () -> get_exn extendee)
   let set extendee t =
     let extensions' = Runtime'.Extensions.set Runtime'.Serialize.C.(basic_opt (1074, (message (fun t -> Options.to_proto' t)))) (extendee.Imported'modules.Descriptor.Google.Protobuf.FileOptions.extensions') t in
-    { extendee with Imported'modules.Descriptor.Google.Protobuf.FileOptions.extensions' = extensions' }
+    { extendee with Imported'modules.Descriptor.Google.Protobuf.FileOptions.extensions' = extensions' } [@@warning "-23"]
 
 end

--- a/src/spec/plugin.ml
+++ b/src/spec/plugin.ml
@@ -29,7 +29,7 @@ module rec Google : sig
       module rec Version : sig
         val name': unit -> string
         type t = { major: int option; minor: int option; patch: int option; suffix: string option }
-        val make : ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
+        val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -38,7 +38,7 @@ module rec Google : sig
       and CodeGeneratorRequest : sig
         val name': unit -> string
         type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
-        val make : ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
+        val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -54,7 +54,7 @@ module rec Google : sig
         and File : sig
           val name': unit -> string
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
-          val make : ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
+          val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
           val to_proto: t -> Runtime'.Writer.t
           val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -62,7 +62,7 @@ module rec Google : sig
         end
         val name': unit -> string
         type t = { error: string option; supported_features: int option; file: File.t list }
-        val make : ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
+        val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -76,7 +76,7 @@ end = struct
       module rec Version : sig
         val name': unit -> string
         type t = { major: int option; minor: int option; patch: int option; suffix: string option }
-        val make : ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
+        val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -85,7 +85,7 @@ end = struct
       and CodeGeneratorRequest : sig
         val name': unit -> string
         type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
-        val make : ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
+        val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -101,7 +101,7 @@ end = struct
         and File : sig
           val name': unit -> string
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
-          val make : ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
+          val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
           val to_proto: t -> Runtime'.Writer.t
           val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -109,7 +109,7 @@ end = struct
         end
         val name': unit -> string
         type t = { error: string option; supported_features: int option; file: File.t list }
-        val make : ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
+        val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -121,7 +121,7 @@ end = struct
       module rec Version : sig
         val name': unit -> string
         type t = { major: int option; minor: int option; patch: int option; suffix: string option }
-        val make : ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
+        val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -130,7 +130,7 @@ end = struct
       and CodeGeneratorRequest : sig
         val name': unit -> string
         type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
-        val make : ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
+        val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -146,7 +146,7 @@ end = struct
         and File : sig
           val name': unit -> string
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
-          val make : ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
+          val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
           val to_proto: t -> Runtime'.Writer.t
           val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -154,7 +154,7 @@ end = struct
         end
         val name': unit -> string
         type t = { error: string option; supported_features: int option; file: File.t list }
-        val make : ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
+        val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -164,7 +164,7 @@ end = struct
       module rec Version : sig
         val name': unit -> string
         type t = { major: int option; minor: int option; patch: int option; suffix: string option }
-        val make : ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
+        val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -174,25 +174,21 @@ end = struct
         type t = { major: int option; minor: int option; patch: int option; suffix: string option }
         let make ?major ?minor ?patch ?suffix () = { major; minor; patch; suffix }
         let to_proto' =
-          let apply = fun ~f:f' writer { major; minor; patch; suffix } -> f' [] writer major minor patch suffix in
           let spec = Runtime'.Serialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, string) ^:: nil ) in
-          let serialize = Runtime'.Serialize.serialize [] spec in
-          fun writer t -> apply ~f:serialize writer t
+          let serialize = Runtime'.Serialize.serialize spec in
+          fun writer { major; minor; patch; suffix } -> serialize writer major minor patch suffix
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
         let from_proto_exn =
-          let constructor = fun major minor patch suffix _extensions -> { major; minor; patch; suffix } in
+          let constructor = fun major minor patch suffix -> { major; minor; patch; suffix } in
           let spec = Runtime'.Deserialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, string) ^:: nil ) in
-          let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-          fun writer -> deserialize writer
-          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+          Runtime'.Deserialize.deserialize spec constructor
+        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       and CodeGeneratorRequest : sig
         val name': unit -> string
         type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
-        val make : ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
+        val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -202,20 +198,16 @@ end = struct
         type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
         let make ?(file_to_generate = []) ?parameter ?compiler_version ?(proto_file = []) () = { file_to_generate; parameter; compiler_version; proto_file }
         let to_proto' =
-          let apply = fun ~f:f' writer { file_to_generate; parameter; compiler_version; proto_file } -> f' [] writer file_to_generate parameter compiler_version proto_file in
           let spec = Runtime'.Serialize.C.( repeated (1, string, not_packed) ^:: basic_opt (2, string) ^:: basic_opt (3, (message (fun t -> Version.to_proto' t))) ^:: repeated (15, (message (fun t -> Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.to_proto' t)), not_packed) ^:: nil ) in
-          let serialize = Runtime'.Serialize.serialize [] spec in
-          fun writer t -> apply ~f:serialize writer t
+          let serialize = Runtime'.Serialize.serialize spec in
+          fun writer { file_to_generate; parameter; compiler_version; proto_file } -> serialize writer file_to_generate parameter compiler_version proto_file
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
         let from_proto_exn =
-          let constructor = fun file_to_generate parameter compiler_version proto_file _extensions -> { file_to_generate; parameter; compiler_version; proto_file } in
+          let constructor = fun file_to_generate parameter compiler_version proto_file -> { file_to_generate; parameter; compiler_version; proto_file } in
           let spec = Runtime'.Deserialize.C.( repeated (1, string, not_packed) ^:: basic_opt (2, string) ^:: basic_opt (3, (message (fun t -> Version.from_proto_exn t))) ^:: repeated (15, (message (fun t -> Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.from_proto_exn t)), not_packed) ^:: nil ) in
-          let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-          fun writer -> deserialize writer
-          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+          Runtime'.Deserialize.deserialize spec constructor
+        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       and CodeGeneratorResponse : sig
         module rec Feature : sig
@@ -227,7 +219,7 @@ end = struct
         and File : sig
           val name': unit -> string
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
-          val make : ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
+          val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
           val to_proto: t -> Runtime'.Writer.t
           val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -235,7 +227,7 @@ end = struct
         end
         val name': unit -> string
         type t = { error: string option; supported_features: int option; file: File.t list }
-        val make : ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
+        val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -262,7 +254,7 @@ end = struct
         and File : sig
           val name': unit -> string
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
-          val make : ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
+          val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
           val to_proto: t -> Runtime'.Writer.t
           val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -272,39 +264,31 @@ end = struct
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
           let make ?name ?insertion_point ?content ?generated_code_info () = { name; insertion_point; content; generated_code_info }
           let to_proto' =
-            let apply = fun ~f:f' writer { name; insertion_point; content; generated_code_info } -> f' [] writer name insertion_point content generated_code_info in
             let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (15, string) ^:: basic_opt (16, (message (fun t -> Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.to_proto' t))) ^:: nil ) in
-            let serialize = Runtime'.Serialize.serialize [] spec in
-            fun writer t -> apply ~f:serialize writer t
+            let serialize = Runtime'.Serialize.serialize spec in
+            fun writer { name; insertion_point; content; generated_code_info } -> serialize writer name insertion_point content generated_code_info
 
           let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
           let from_proto_exn =
-            let constructor = fun name insertion_point content generated_code_info _extensions -> { name; insertion_point; content; generated_code_info } in
+            let constructor = fun name insertion_point content generated_code_info -> { name; insertion_point; content; generated_code_info } in
             let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (15, string) ^:: basic_opt (16, (message (fun t -> Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.from_proto_exn t))) ^:: nil ) in
-            let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-            fun writer -> deserialize writer
-            let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+            Runtime'.Deserialize.deserialize spec constructor
+          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
         end
         let name' () = "plugin.google.protobuf.compiler.CodeGeneratorResponse"
         type t = { error: string option; supported_features: int option; file: File.t list }
         let make ?error ?supported_features ?(file = []) () = { error; supported_features; file }
         let to_proto' =
-          let apply = fun ~f:f' writer { error; supported_features; file } -> f' [] writer error supported_features file in
           let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, uint64_int) ^:: repeated (15, (message (fun t -> File.to_proto' t)), not_packed) ^:: nil ) in
-          let serialize = Runtime'.Serialize.serialize [] spec in
-          fun writer t -> apply ~f:serialize writer t
+          let serialize = Runtime'.Serialize.serialize spec in
+          fun writer { error; supported_features; file } -> serialize writer error supported_features file
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
         let from_proto_exn =
-          let constructor = fun error supported_features file _extensions -> { error; supported_features; file } in
+          let constructor = fun error supported_features file -> { error; supported_features; file } in
           let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, uint64_int) ^:: repeated (15, (message (fun t -> File.from_proto_exn t)), not_packed) ^:: nil ) in
-          let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-          fun writer -> deserialize writer
-          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+          Runtime'.Deserialize.deserialize spec constructor
+        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
     end
   end

--- a/test/dune
+++ b/test/dune
@@ -35,7 +35,7 @@
 
 (rule
  (targets
-   basic.ml primitive_types.ml int_types.ml repeated.ml enum.ml
+   basic.ml primitive_types.ml int_types.ml repeated.ml enum.ml empty_message.ml
    message.ml oneof.ml map.ml package.ml include.ml included.ml large.ml
    included2.ml included3_dash.ml service.ml recursive.ml protocol.ml name_clash.ml
    name_clash_mangle.ml proto2.ml packed.ml mangle_names.ml extensions.ml
@@ -43,8 +43,8 @@
  (deps
   (:plugin ../src/plugin/protoc_gen_ocaml.exe)
   (:proto
-    basic.proto primitive_types.proto int_types.proto repeated.proto
-    enum.proto message.proto oneof.proto map.proto package.proto large.proto
+    basic.proto primitive_types.proto int_types.proto repeated.proto enum.proto empty_message.proto
+    message.proto oneof.proto map.proto package.proto large.proto
     include.proto included.proto included2.proto included3-dash.proto service.proto
     recursive.proto protocol.proto name_clash.proto name_clash_mangle.proto
     proto2.proto packed.proto mangle_names.proto extensions.proto options.proto

--- a/test/empty_message.proto
+++ b/test/empty_message.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+message Empty { }

--- a/test/empty_message_test.ml
+++ b/test/empty_message_test.ml
@@ -1,0 +1,6 @@
+let%expect_test _ =
+  let module T = Empty_message.Empty in
+  let validate = T.make () in
+  let t = () in
+  Test_lib.test_encode (module T) ~validate t;
+  [%expect {| |}]

--- a/test/extensions.proto
+++ b/test/extensions.proto
@@ -26,3 +26,11 @@ extend Foo {
     optional uint32 a = 131;
     optional uint32 b = 132 [default = 13];
 }
+
+message Bar {
+    extensions 100 to 199;
+}
+
+extend Bar {
+    optional uint32 z = 131;
+}

--- a/test/extensions_test.ml
+++ b/test/extensions_test.ml
@@ -25,7 +25,7 @@ let%expect_test _ =
   in
   ();
   [%expect {|
-    { extensions' = (128, (Field.Varint 7L)); bar = (Some 5) }
+    { bar = (Some 5); extensions' = (128, (Field.Varint 7L)) }
     Ok (Some 7) |}]
 
 let%expect_test _ =
@@ -37,7 +37,7 @@ let%expect_test _ =
   print_endline ([%show: Extensions.Foo.t] foo);
   ();
   [%expect {|
-    { extensions' = (128, (Field.Varint 0L)); bar = (Some 5) } |}]
+    { bar = (Some 5); extensions' = (128, (Field.Varint 0L)) } |}]
 
 let%expect_test _ =
   let foo = Extensions.Foo.{ bar = Some 5; extensions' = Ocaml_protoc_plugin.Extensions.default } in
@@ -103,14 +103,14 @@ let%expect_test _ =
   print_endline ([%show: Extensions.Foo.t] foo);
   ();
   [%expect {|
-    { extensions' = ; bar = (Some 5) }
+    { bar = (Some 5); extensions' =  }
     Set A = Some 7
-    { extensions' = (131, (Field.Varint 7L)); bar = (Some 5) }
+    { bar = (Some 5); extensions' = (131, (Field.Varint 7L)) }
     Set A = None
-    { extensions' = ; bar = (Some 5) }
+    { bar = (Some 5); extensions' =  }
     Set B = 15: 15
-    { extensions' = (132, (Field.Varint 15L)); bar = (Some 5) }
+    { bar = (Some 5); extensions' = (132, (Field.Varint 15L)) }
     Set B = 13: 13
-    { extensions' = ; bar = (Some 5) }
+    { bar = (Some 5); extensions' =  }
     Set B = 0: 0
-    { extensions' = (132, (Field.Varint 0L)); bar = (Some 5) } |}]
+    { bar = (Some 5); extensions' = (132, (Field.Varint 0L)) } |}]


### PR DESCRIPTION
Improve handling of extensions.
This generalizes extension handling by adding extensions to the serialization and deserialization spec. This allows cleaner less explicit handling of extensions and some optimization where empty lists does not need to be passed to the constructor. 

This PR is based on #55. I recommend reviewing after #55 has been merged, or to only review the last five commits.