### PR TITLE
Expand testing 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /_build/
 /_opam/
 /*.install
+_coverage
 .merlin
 node_modules
 lib

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,16 @@ clean: ## Clean
 	@dune clean
 
 .PHONY: test
-test: build
 test: ## Run tests
-	@dune runtest --force
+	@dune runtest
+
+.PHONY: bisect
+bisect: ## Run tests in bisect mode
+	@rm -fr _coverage
+	@find . -name '*.coverage' | xargs -r rm -f
+	@dune runtest --instrument-with bisect_ppx --force
+	bisect-ppx-report html
+	open _coverage/index.html
 
 .PHONY: install
 install: build ## Install

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ gh-pages: doc ## Publish documentation
 
 .PHONY: bench
 bench: ## Run benchmark to compare with ocaml-protoc
-	dune exec bench/bench.exe
+	dune exec bench/bench.exe --profile=bench
 
 .PHONY: force
 force:

--- a/bench/empty.proto
+++ b/bench/empty.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+
+message M {
+}

--- a/bench/plugin/dune
+++ b/bench/plugin/dune
@@ -1,12 +1,12 @@
 (rule
  (targets
-   bench.ml
+   bench.ml empty.ml
    int64.ml  string.ml  float.ml  enum.ml
    int64_list.ml  string_list.ml  float_list.ml  enum_list.ml
  )
  (deps
   (:proto
-    ../bench.proto
+    ../bench.proto ../empty.proto
     ../int64.proto ../string.proto ../float.proto ../enum.proto
     ../int64_list.proto ../string_list.proto ../float_list.proto ../enum_list.proto)
   (:plugin ../../src/plugin/protoc_gen_ocaml.exe)

--- a/bench/protoc/dune
+++ b/bench/protoc/dune
@@ -1,6 +1,6 @@
 (rule
  (targets
-   bench.ml bench.mli
+   bench.ml bench.mli empty.ml empty.mli
    int64.ml  string.ml  float.ml  enum.ml
    int64.mli string.mli float.mli enum.mli
    int64_list.ml  string_list.ml  float_list.ml  enum_list.ml
@@ -8,7 +8,7 @@
  )
  (deps
   (:proto
-    ../bench.proto
+    ../bench.proto ../empty.proto
     ../int64.proto ../string.proto ../float.proto ../enum.proto
     ../int64_list.proto ../string_list.proto ../float_list.proto ../enum_list.proto))
  (action

--- a/dune-workspace
+++ b/dune-workspace
@@ -1,0 +1,3 @@
+(lang dune 3.12)
+(env (bench (ocamlopt_flags :standard -O3 -unbox-closures -unboxed-types -remove-unused-arguments -rounds 4 -inline 100.00 -inline-max-depth 5 -inline-max-unroll 5)))
+;(env (bench (ocamlopt_flags :standard -O3 -rounds 10 -unbox-closures -inline 100.00 -inline-max-depth 5 -remove-unused-arguments)))

--- a/ocaml-protoc-plugin.opam
+++ b/ocaml-protoc-plugin.opam
@@ -19,6 +19,7 @@ depends: [
   "ppx_expect" {with-test}
   "ppx_inline_test" {with-test}
   "ppx_deriving" {with-test}
+  "bisect_ppx" {with-test}
   "conf-pkg-config" {build}
 ]
 

--- a/src/ocaml_protoc_plugin/deserialize.mli
+++ b/src/ocaml_protoc_plugin/deserialize.mli
@@ -1,5 +1,5 @@
 module C = Spec.Deserialize.C
 
-val deserialize: (int * int) list ->
-  ('constr, (int * Field.t) list -> 'a) Spec.Deserialize.compound_list ->
+val deserialize:
+  ('constr, 'a) Spec.Deserialize.compound_list ->
   'constr -> Reader.t -> 'a

--- a/src/ocaml_protoc_plugin/deserialize.mli
+++ b/src/ocaml_protoc_plugin/deserialize.mli
@@ -3,3 +3,13 @@ module C = Spec.Deserialize.C
 val deserialize:
   ('constr, 'a) Spec.Deserialize.compound_list ->
   'constr -> Reader.t -> 'a
+
+(** **)
+val deserialize_full:
+  ('constr, 'a) Spec.Deserialize.compound_list ->
+  'constr -> Reader.t -> 'a
+
+val deserialize_fast:
+  ('constr, 'a) Spec.Deserialize.compound_list ->
+  'constr -> Reader.t -> 'a
+(** **)

--- a/src/ocaml_protoc_plugin/dune
+++ b/src/ocaml_protoc_plugin/dune
@@ -4,4 +4,5 @@
  (synopsis "Serialization and deserialization of protobuf types")
  (inline_tests)
  (preprocess (pps ppx_expect))
+ (instrumentation (backend bisect_ppx))
 )

--- a/src/ocaml_protoc_plugin/extensions.ml
+++ b/src/ocaml_protoc_plugin/extensions.ml
@@ -11,6 +11,7 @@ let compare _ _ = 0
 let index_of_spec: type a. a Spec.Serialize.compound -> int = function
   | Basic (index, _, _) -> index
   | Basic_opt (index, _) -> index
+  | Basic_req (index, _) -> index
   | Repeated (index, _, _) -> index
   | Oneof _ -> failwith "Oneof fields not allowed in extensions"
 

--- a/src/ocaml_protoc_plugin/extensions.ml
+++ b/src/ocaml_protoc_plugin/extensions.ml
@@ -17,11 +17,11 @@ let index_of_spec: type a. a Spec.Serialize.compound -> int = function
 let get: type a. a Spec.Deserialize.compound -> t -> a = fun spec t ->
   let writer = Writer.of_list t in
   let reader = Writer.contents writer |> Reader.create in
-  Deserialize.deserialize [] Spec.Deserialize.(Cons (spec, Nil)) (fun a _ -> a) reader
+  Deserialize.deserialize Spec.Deserialize.(Cons (spec, Nil)) (fun a -> a) reader
 
 let set: type a. a Spec.Serialize.compound -> t -> a -> t = fun spec t v ->
   let writer = Writer.init () in
-  let writer = Serialize.serialize [] Spec.Serialize.(Cons (spec, Nil)) [] writer v in
+  let writer = Serialize.serialize Spec.Serialize.(Cons (spec, Nil)) writer v in
   let index = index_of_spec spec in
   let fields =
     Writer.contents writer

--- a/src/ocaml_protoc_plugin/merge.ml
+++ b/src/ocaml_protoc_plugin/merge.ml
@@ -1,0 +1,21 @@
+(** Merge a two values. Need to match on the spec to merge messages recursivly *)
+let merge: type t. t Spec.Deserialize.compound -> t -> t -> t = fun spec t t' -> match spec with
+  | Spec.Deserialize.Basic (_field, Message (_, merge), _) -> merge t t'
+  | Spec.Deserialize.Basic (_field, _spec, Some default) when t' = default -> t
+  | Spec.Deserialize.Basic (_field, _spec, _) -> t'
+  | Spec.Deserialize.Basic_opt (_field, Message (_, merge)) ->
+    begin
+      match t, t' with
+      | None, None -> None
+      | Some t, None -> Some t
+      | None, Some t -> Some t
+      | Some t, Some t' -> Some (merge t t')
+    end
+  | Spec.Deserialize.Basic_opt (_field, _spec) -> begin
+      match t' with
+      | Some _ -> t'
+      | None -> t
+    end
+  | Spec.Deserialize.Repeated (_field, _, _) -> t @ t'
+  (* | Spec.Deserialize.Oneof _ when t' = `not_set -> t *)
+  | Spec.Deserialize.Oneof _ -> failwith "Implementation is part of generated code"

--- a/src/ocaml_protoc_plugin/merge.ml
+++ b/src/ocaml_protoc_plugin/merge.ml
@@ -1,8 +1,16 @@
 (** Merge a two values. Need to match on the spec to merge messages recursivly *)
 let merge: type t. t Spec.Deserialize.compound -> t -> t -> t = fun spec t t' -> match spec with
-  | Spec.Deserialize.Basic (_field, Message (_, merge), _) -> merge t t'
-  | Spec.Deserialize.Basic (_field, _spec, Some default) when t' = default -> t
+  | Spec.Deserialize.Basic (_field, Message (_, _), _) -> failwith "Messages with defaults cannot happen"
+  | Spec.Deserialize.Basic (_field, _spec, default) when t' = default -> t
   | Spec.Deserialize.Basic (_field, _spec, _) -> t'
+
+    (* The spec states that proto2 required fields must be transmitted exactly once.
+       So merging these fields is not possible. The essentially means that you cannot merge
+       proto2 messages containing required fields.
+       In this implementation, we choose to ignore this, and adopt 'keep last'
+    *)
+  | Spec.Deserialize.Basic_req (_field, Message (_, merge)) -> merge t t'
+  | Spec.Deserialize.Basic_req (_field, _spec) -> t'
   | Spec.Deserialize.Basic_opt (_field, Message (_, merge)) ->
     begin
       match t, t' with

--- a/src/ocaml_protoc_plugin/ocaml_protoc_plugin.ml
+++ b/src/ocaml_protoc_plugin/ocaml_protoc_plugin.ml
@@ -3,6 +3,7 @@ module Serialize = Serialize
 module Deserialize = Deserialize
 module Spec = Spec
 module Runtime = Runtime
+module Field = Field
 (**/**)
 
 module Reader = Reader

--- a/src/ocaml_protoc_plugin/reader.ml
+++ b/src/ocaml_protoc_plugin/reader.ml
@@ -92,6 +92,11 @@ let read_field_content: Field.field_type -> t -> Field.t = function
   | Length_delimited -> fun r -> Length_delimited (read_length_delimited r)
   | Fixed32 -> fun r -> Field.Fixed_32_bit (read_fixed32 r)
 
+let next_field_header reader =
+  match has_more reader with
+  | true -> Some (read_field_header reader)
+  | false -> None
+
 let to_list: t -> (int * Field.t) list =
   let read_field t =
     let (tpe, index) = read_field_header t in

--- a/src/ocaml_protoc_plugin/reader.mli
+++ b/src/ocaml_protoc_plugin/reader.mli
@@ -16,4 +16,5 @@ val read_fixed64 : t -> int64
 
 val read_varint : t -> int64
 val read_varint_unboxed : t -> int
+val next_field_header : t -> (Field.field_type * int) option
 (**/**)

--- a/src/ocaml_protoc_plugin/result.mli
+++ b/src/ocaml_protoc_plugin/result.mli
@@ -5,7 +5,7 @@ type error =
   | `Illegal_value of string * Field.t
   | `Unknown_enum_value of int
   | `Oneof_missing
-  | `Required_field_missing ]
+  | `Required_field_missing of int * string ]
 
 exception Error of error
 

--- a/src/ocaml_protoc_plugin/runtime.ml
+++ b/src/ocaml_protoc_plugin/runtime.ml
@@ -7,4 +7,5 @@ module Runtime' = struct
   module Extensions = Extensions
   module Reader = Reader
   module Writer = Writer
+  module Merge = Merge
 end

--- a/src/ocaml_protoc_plugin/serialize.ml
+++ b/src/ocaml_protoc_plugin/serialize.ml
@@ -120,16 +120,15 @@ let rec write: type a. a compound -> Writer.t -> a -> unit = function
   *)
   | Basic (index, spec, default) -> begin
       let write = write_field spec index in
-      match default with
-      | Some default ->
-        fun writer v -> begin
-            match v with
-            | v when v = default -> ()
-            | v -> write v writer
-        end
-      | None ->
-        fun writer v -> write v writer
+      let writer writer = function
+        | v when v = default -> ()
+        | v -> write v writer
+      in
+      writer
     end
+  | Basic_req (index, spec) ->
+      let write = write_field spec index in
+      fun writer v -> write v writer
   | Basic_opt (index, spec) -> begin
       let write = write_field spec index in
       fun writer v ->
@@ -145,7 +144,7 @@ let rec write: type a. a compound -> Writer.t -> a -> unit = function
           (* Wonder if we could get the specs before calling v. Wonder what f is? *)
           (* We could prob. return a list of all possible values + f v -> v. *)
             let Oneof_elem (index, spec, v) = f v in
-            write (Basic (index, spec, None)) writer v
+            write (Basic_req (index, spec)) writer v
     end
 
 let in_extension_ranges extension_ranges index =

--- a/src/ocaml_protoc_plugin/spec.ml
+++ b/src/ocaml_protoc_plugin/spec.ml
@@ -44,7 +44,7 @@ module Make(T : T) = struct
     | Message : ('a, ((Reader.t -> 'a) * 'a merge), Writer.t -> 'a -> Writer.t) T.dir -> 'a spec
 
   (* Existential types *)
-  type espec = Espec: _ spec -> espec
+  type espec = Espec: _ spec -> espec [@@unboxed]
 
   type _ oneof =
     | Oneof_elem : int * 'b spec * ('a, ('b -> 'a), 'b) T.dir -> 'a oneof
@@ -64,11 +64,13 @@ module Make(T : T) = struct
     | Oneof : ('a, 'a oneof list, 'a -> unit oneof) T.dir -> ([> `not_set ] as 'a) compound
 
   type (_, _) compound_list =
+    (* End of list *)
     | Nil : ('a, 'a) compound_list
 
     (* Nil_ext denotes that the message contains extensions *)
     | Nil_ext: extension_ranges -> (extensions -> 'a, 'a) compound_list
 
+    (* List element *)
     | Cons : ('a compound) * ('b, 'c) compound_list -> ('a -> 'b, 'c) compound_list
 
   module C = struct

--- a/src/ocaml_protoc_plugin/spec.ml
+++ b/src/ocaml_protoc_plugin/spec.ml
@@ -50,14 +50,25 @@ module Make(T : T) = struct
     | Oneof_elem : int * 'b spec * ('a, ('b -> 'a), 'b) T.dir -> 'a oneof
 
   type _ compound =
-    | Basic : int * 'a spec * 'a option -> 'a compound
+    (* A field, where the default value is know (and set). This cannot be used for message types *)
+    | Basic : int * 'a spec * 'a -> 'a compound
+
+    (* Proto2/proto3 optional fields. *)
     | Basic_opt : int * 'a spec -> 'a option compound
+
+    (* Proto2 required fields (and oneof fields) *)
+    | Basic_req : int * 'a spec -> 'a compound
+
+    (* Repeated fields *)
     | Repeated : int * 'a spec * packed -> 'a list compound
     | Oneof : ('a, 'a oneof list, 'a -> unit oneof) T.dir -> ([> `not_set ] as 'a) compound
 
   type (_, _) compound_list =
     | Nil : ('a, 'a) compound_list
+
+    (* Nil_ext denotes that the message contains extensions *)
     | Nil_ext: extension_ranges -> (extensions -> 'a, 'a) compound_list
+
     | Cons : ('a compound) * ('b, 'c) compound_list -> ('a -> 'b, 'c) compound_list
 
   module C = struct
@@ -97,6 +108,7 @@ module Make(T : T) = struct
 
     let repeated (i, s, p) = Repeated (i, s, p)
     let basic (i, s, d) = Basic (i, s, d)
+    let basic_req (i, s) = Basic_req (i, s)
     let basic_opt (i, s) = Basic_opt (i, s)
     let oneof s = Oneof s
     let oneof_elem (a, b, c) = Oneof_elem (a, b, c)

--- a/src/ocaml_protoc_plugin/spec.ml
+++ b/src/ocaml_protoc_plugin/spec.ml
@@ -7,6 +7,7 @@ module Make(T : T) = struct
   type packed = Packed | Not_packed
   type extension_ranges = (int * int) list
   type extensions = (int * Field.t) list
+  type 'a merge = 'a -> 'a -> 'a
 
   type _ spec =
     | Double : float spec
@@ -40,7 +41,10 @@ module Make(T : T) = struct
     | String : string spec
     | Bytes : bytes spec
     | Enum :  ('a, int -> 'a, 'a -> int) T.dir -> 'a spec
-    | Message : ('a, Reader.t -> 'a, Writer.t -> 'a -> Writer.t) T.dir -> 'a spec
+    | Message : ('a, ((Reader.t -> 'a) * 'a merge), Writer.t -> 'a -> Writer.t) T.dir -> 'a spec
+
+  (* Existential types *)
+  type espec = Espec: _ spec -> espec
 
   type _ oneof =
     | Oneof_elem : int * 'b spec * ('a, ('b -> 'a), 'b) T.dir -> 'a oneof

--- a/src/ocaml_protoc_plugin/spec.ml
+++ b/src/ocaml_protoc_plugin/spec.ml
@@ -5,6 +5,8 @@ end
 module Make(T : T) = struct
 
   type packed = Packed | Not_packed
+  type extension_ranges = (int * int) list
+  type extensions = (int * Field.t) list
 
   type _ spec =
     | Double : float spec
@@ -51,6 +53,7 @@ module Make(T : T) = struct
 
   type (_, _) compound_list =
     | Nil : ('a, 'a) compound_list
+    | Nil_ext: extension_ranges -> (extensions -> 'a, 'a) compound_list
     | Cons : ('a compound) * ('b, 'c) compound_list -> ('a -> 'b, 'c) compound_list
 
   module C = struct
@@ -99,6 +102,7 @@ module Make(T : T) = struct
 
     let ( ^:: ) a b = Cons (a, b)
     let nil = Nil
+    let nil_ext extension_ranges = Nil_ext extension_ranges
 
     let show: type a. a spec -> string = function
       | Double -> "Double"

--- a/src/plugin/code.ml
+++ b/src/plugin/code.ml
@@ -29,8 +29,13 @@ let emit t indent fmt =
     | n -> String.sub ~pos:0 ~len:(String.length s - n) s
   in
   let prepend s =
-    String.split_on_char ~sep:'\n' s
-    |> List.iter ~f:(fun s -> t.code <- (trim_end ~char:' ' (t.indent ^ s)) :: t.code)
+    match String.split_on_char ~sep:'\n' s with
+    | line :: lines ->
+      t.code <- (trim_end ~char:' ' (t.indent ^ line)) :: t.code;
+      incr t;
+      List.iter lines ~f:(fun line -> t.code <- (trim_end ~char:' ' (t.indent ^ line)) :: t.code);
+      decr t;
+    | [] -> ()
   in
   let emit s =
     match indent with

--- a/src/plugin/dune
+++ b/src/plugin/dune
@@ -3,4 +3,5 @@
  (public_name protoc-gen-ocaml)
  (libraries spec)
  (package ocaml-protoc-plugin)
+ (instrumentation (backend bisect_ppx))
 )

--- a/src/plugin/parse.ml
+++ b/src/plugin/parse.ml
@@ -1,9 +1,3 @@
-(* Should we generate an ast????
-   It would be simpler, and then generate the code based on that one
-   The question is if this is actually harder than just parsing and emitting                                             OTOH: Its easier to create interfaces and modules once we know all the types.
-   We also need to do a lexiographic ordering. No I dont!!!
-*)
-
 type t = {
   filename : string;
   package : string option;

--- a/src/plugin/types.mli
+++ b/src/plugin/types.mli
@@ -26,6 +26,6 @@ val make:
   syntax:[ `Proto2 | `Proto3 ] ->
   is_cyclic: bool ->
   is_map_entry: bool ->
-  has_extensions: bool ->
+  extension_ranges: (int*int) list ->
   scope:Scope.t ->
   fields:FieldDescriptorProto.t list -> OneofDescriptorProto.t list -> t

--- a/src/plugin/types.mli
+++ b/src/plugin/types.mli
@@ -8,6 +8,7 @@ type t = {
   serialize_spec: string;
   default_constructor_sig: string;
   default_constructor_impl: string;
+  merge_impl: string;
 }
 
 type field_spec = {

--- a/src/spec/descriptor.ml
+++ b/src/spec/descriptor.ml
@@ -23,7 +23,7 @@ module rec Google : sig
     module rec FileDescriptorSet : sig
       val name': unit -> string
       type t = FileDescriptorProto.t list
-      val make : ?file:FileDescriptorProto.t list -> unit -> t
+      val make: ?file:FileDescriptorProto.t list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -32,7 +32,7 @@ module rec Google : sig
     and FileDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; package: string option; dependency: string list; message_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; service: ServiceDescriptorProto.t list; extension: FieldDescriptorProto.t list; options: FileOptions.t option; source_code_info: SourceCodeInfo.t option; public_dependency: int list; weak_dependency: int list; syntax: string option }
-      val make : ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
+      val make: ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -42,7 +42,7 @@ module rec Google : sig
       module rec ExtensionRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
-        val make : ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
+        val make: ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -51,7 +51,7 @@ module rec Google : sig
       and ReservedRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option }
-        val make : ?start:int -> ?end':int -> unit -> t
+        val make: ?start:int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -59,7 +59,7 @@ module rec Google : sig
       end
       val name': unit -> string
       type t = { name: string option; field: FieldDescriptorProto.t list; nested_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; extension_range: ExtensionRange.t list; extension: FieldDescriptorProto.t list; options: MessageOptions.t option; oneof_decl: OneofDescriptorProto.t list; reserved_range: ReservedRange.t list; reserved_name: string list }
-      val make : ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      val make: ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -67,8 +67,8 @@ module rec Google : sig
     end
     and ExtensionRangeOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -89,7 +89,7 @@ module rec Google : sig
       end
       val name': unit -> string
       type t = { name: string option; extendee: string option; number: int option; label: Label.t option; type': Type.t option; type_name: string option; default_value: string option; options: FieldOptions.t option; oneof_index: int option; json_name: string option; proto3_optional: bool option }
-      val make : ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
+      val make: ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -98,7 +98,7 @@ module rec Google : sig
     and OneofDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; options: OneofOptions.t option }
-      val make : ?name:string -> ?options:OneofOptions.t -> unit -> t
+      val make: ?name:string -> ?options:OneofOptions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -108,7 +108,7 @@ module rec Google : sig
       module rec EnumReservedRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option }
-        val make : ?start:int -> ?end':int -> unit -> t
+        val make: ?start:int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -116,7 +116,7 @@ module rec Google : sig
       end
       val name': unit -> string
       type t = { name: string option; value: EnumValueDescriptorProto.t list; options: EnumOptions.t option; reserved_range: EnumReservedRange.t list; reserved_name: string list }
-      val make : ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      val make: ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -125,7 +125,7 @@ module rec Google : sig
     and EnumValueDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; number: int option; options: EnumValueOptions.t option }
-      val make : ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
+      val make: ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -134,7 +134,7 @@ module rec Google : sig
     and ServiceDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; method': MethodDescriptorProto.t list; options: ServiceOptions.t option }
-      val make : ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
+      val make: ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -143,7 +143,7 @@ module rec Google : sig
     and MethodDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; input_type: string option; output_type: string option; options: MethodOptions.t option; client_streaming: bool; server_streaming: bool }
-      val make : ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
+      val make: ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -157,8 +157,8 @@ module rec Google : sig
         val from_int_exn: int -> t
       end
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -166,8 +166,8 @@ module rec Google : sig
     end
     and MessageOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -187,8 +187,8 @@ module rec Google : sig
         val from_int_exn: int -> t
       end
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -196,8 +196,8 @@ module rec Google : sig
     end
     and OneofOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -205,8 +205,8 @@ module rec Google : sig
     end
     and EnumOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -214,8 +214,8 @@ module rec Google : sig
     end
     and EnumValueOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -223,8 +223,8 @@ module rec Google : sig
     end
     and ServiceOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -238,8 +238,8 @@ module rec Google : sig
         val from_int_exn: int -> t
       end
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -249,7 +249,7 @@ module rec Google : sig
       module rec NamePart : sig
         val name': unit -> string
         type t = { name_part: string; is_extension: bool }
-        val make : name_part:string -> is_extension:bool -> unit -> t
+        val make: name_part:string -> is_extension:bool -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -257,7 +257,7 @@ module rec Google : sig
       end
       val name': unit -> string
       type t = { name: NamePart.t list; identifier_value: string option; positive_int_value: int option; negative_int_value: int option; double_value: float option; string_value: bytes option; aggregate_value: string option }
-      val make : ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
+      val make: ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -267,7 +267,7 @@ module rec Google : sig
       module rec Location : sig
         val name': unit -> string
         type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
-        val make : ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
+        val make: ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -275,7 +275,7 @@ module rec Google : sig
       end
       val name': unit -> string
       type t = Location.t list
-      val make : ?location:Location.t list -> unit -> t
+      val make: ?location:Location.t list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -285,7 +285,7 @@ module rec Google : sig
       module rec Annotation : sig
         val name': unit -> string
         type t = { path: int list; source_file: string option; begin': int option; end': int option }
-        val make : ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
+        val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -293,7 +293,7 @@ module rec Google : sig
       end
       val name': unit -> string
       type t = Annotation.t list
-      val make : ?annotation:Annotation.t list -> unit -> t
+      val make: ?annotation:Annotation.t list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -305,7 +305,7 @@ end = struct
     module rec FileDescriptorSet : sig
       val name': unit -> string
       type t = FileDescriptorProto.t list
-      val make : ?file:FileDescriptorProto.t list -> unit -> t
+      val make: ?file:FileDescriptorProto.t list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -314,7 +314,7 @@ end = struct
     and FileDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; package: string option; dependency: string list; message_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; service: ServiceDescriptorProto.t list; extension: FieldDescriptorProto.t list; options: FileOptions.t option; source_code_info: SourceCodeInfo.t option; public_dependency: int list; weak_dependency: int list; syntax: string option }
-      val make : ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
+      val make: ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -324,7 +324,7 @@ end = struct
       module rec ExtensionRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
-        val make : ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
+        val make: ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -333,7 +333,7 @@ end = struct
       and ReservedRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option }
-        val make : ?start:int -> ?end':int -> unit -> t
+        val make: ?start:int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -341,7 +341,7 @@ end = struct
       end
       val name': unit -> string
       type t = { name: string option; field: FieldDescriptorProto.t list; nested_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; extension_range: ExtensionRange.t list; extension: FieldDescriptorProto.t list; options: MessageOptions.t option; oneof_decl: OneofDescriptorProto.t list; reserved_range: ReservedRange.t list; reserved_name: string list }
-      val make : ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      val make: ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -349,8 +349,8 @@ end = struct
     end
     and ExtensionRangeOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -371,7 +371,7 @@ end = struct
       end
       val name': unit -> string
       type t = { name: string option; extendee: string option; number: int option; label: Label.t option; type': Type.t option; type_name: string option; default_value: string option; options: FieldOptions.t option; oneof_index: int option; json_name: string option; proto3_optional: bool option }
-      val make : ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
+      val make: ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -380,7 +380,7 @@ end = struct
     and OneofDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; options: OneofOptions.t option }
-      val make : ?name:string -> ?options:OneofOptions.t -> unit -> t
+      val make: ?name:string -> ?options:OneofOptions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -390,7 +390,7 @@ end = struct
       module rec EnumReservedRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option }
-        val make : ?start:int -> ?end':int -> unit -> t
+        val make: ?start:int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -398,7 +398,7 @@ end = struct
       end
       val name': unit -> string
       type t = { name: string option; value: EnumValueDescriptorProto.t list; options: EnumOptions.t option; reserved_range: EnumReservedRange.t list; reserved_name: string list }
-      val make : ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      val make: ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -407,7 +407,7 @@ end = struct
     and EnumValueDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; number: int option; options: EnumValueOptions.t option }
-      val make : ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
+      val make: ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -416,7 +416,7 @@ end = struct
     and ServiceDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; method': MethodDescriptorProto.t list; options: ServiceOptions.t option }
-      val make : ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
+      val make: ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -425,7 +425,7 @@ end = struct
     and MethodDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; input_type: string option; output_type: string option; options: MethodOptions.t option; client_streaming: bool; server_streaming: bool }
-      val make : ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
+      val make: ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -439,8 +439,8 @@ end = struct
         val from_int_exn: int -> t
       end
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -448,8 +448,8 @@ end = struct
     end
     and MessageOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -469,8 +469,8 @@ end = struct
         val from_int_exn: int -> t
       end
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -478,8 +478,8 @@ end = struct
     end
     and OneofOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -487,8 +487,8 @@ end = struct
     end
     and EnumOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -496,8 +496,8 @@ end = struct
     end
     and EnumValueOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -505,8 +505,8 @@ end = struct
     end
     and ServiceOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -520,8 +520,8 @@ end = struct
         val from_int_exn: int -> t
       end
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -531,7 +531,7 @@ end = struct
       module rec NamePart : sig
         val name': unit -> string
         type t = { name_part: string; is_extension: bool }
-        val make : name_part:string -> is_extension:bool -> unit -> t
+        val make: name_part:string -> is_extension:bool -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -539,7 +539,7 @@ end = struct
       end
       val name': unit -> string
       type t = { name: NamePart.t list; identifier_value: string option; positive_int_value: int option; negative_int_value: int option; double_value: float option; string_value: bytes option; aggregate_value: string option }
-      val make : ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
+      val make: ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -549,7 +549,7 @@ end = struct
       module rec Location : sig
         val name': unit -> string
         type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
-        val make : ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
+        val make: ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -557,7 +557,7 @@ end = struct
       end
       val name': unit -> string
       type t = Location.t list
-      val make : ?location:Location.t list -> unit -> t
+      val make: ?location:Location.t list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -567,7 +567,7 @@ end = struct
       module rec Annotation : sig
         val name': unit -> string
         type t = { path: int list; source_file: string option; begin': int option; end': int option }
-        val make : ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
+        val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -575,7 +575,7 @@ end = struct
       end
       val name': unit -> string
       type t = Annotation.t list
-      val make : ?annotation:Annotation.t list -> unit -> t
+      val make: ?annotation:Annotation.t list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -585,7 +585,7 @@ end = struct
     module rec FileDescriptorSet : sig
       val name': unit -> string
       type t = FileDescriptorProto.t list
-      val make : ?file:FileDescriptorProto.t list -> unit -> t
+      val make: ?file:FileDescriptorProto.t list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -595,25 +595,21 @@ end = struct
       type t = FileDescriptorProto.t list
       let make ?(file = []) () = file
       let to_proto' =
-        let apply = fun ~f:f' writer file -> f' [] writer file in
         let spec = Runtime'.Serialize.C.( repeated (1, (message (fun t -> FileDescriptorProto.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        serialize
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun file _extensions -> file in
+        let constructor = fun file -> file in
         let spec = Runtime'.Deserialize.C.( repeated (1, (message (fun t -> FileDescriptorProto.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and FileDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; package: string option; dependency: string list; message_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; service: ServiceDescriptorProto.t list; extension: FieldDescriptorProto.t list; options: FileOptions.t option; source_code_info: SourceCodeInfo.t option; public_dependency: int list; weak_dependency: int list; syntax: string option }
-      val make : ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
+      val make: ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -623,26 +619,22 @@ end = struct
       type t = { name: string option; package: string option; dependency: string list; message_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; service: ServiceDescriptorProto.t list; extension: FieldDescriptorProto.t list; options: FileOptions.t option; source_code_info: SourceCodeInfo.t option; public_dependency: int list; weak_dependency: int list; syntax: string option }
       let make ?name ?package ?(dependency = []) ?(message_type = []) ?(enum_type = []) ?(service = []) ?(extension = []) ?options ?source_code_info ?(public_dependency = []) ?(weak_dependency = []) ?syntax () = { name; package; dependency; message_type; enum_type; service; extension; options; source_code_info; public_dependency; weak_dependency; syntax }
       let to_proto' =
-        let apply = fun ~f:f' writer { name; package; dependency; message_type; enum_type; service; extension; options; source_code_info; public_dependency; weak_dependency; syntax } -> f' [] writer name package dependency message_type enum_type service extension options source_code_info public_dependency weak_dependency syntax in
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: repeated (3, string, not_packed) ^:: repeated (4, (message (fun t -> DescriptorProto.to_proto' t)), not_packed) ^:: repeated (5, (message (fun t -> EnumDescriptorProto.to_proto' t)), not_packed) ^:: repeated (6, (message (fun t -> ServiceDescriptorProto.to_proto' t)), not_packed) ^:: repeated (7, (message (fun t -> FieldDescriptorProto.to_proto' t)), not_packed) ^:: basic_opt (8, (message (fun t -> FileOptions.to_proto' t))) ^:: basic_opt (9, (message (fun t -> SourceCodeInfo.to_proto' t))) ^:: repeated (10, int32_int, not_packed) ^:: repeated (11, int32_int, not_packed) ^:: basic_opt (12, string) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { name; package; dependency; message_type; enum_type; service; extension; options; source_code_info; public_dependency; weak_dependency; syntax } -> serialize writer name package dependency message_type enum_type service extension options source_code_info public_dependency weak_dependency syntax
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun name package dependency message_type enum_type service extension options source_code_info public_dependency weak_dependency syntax _extensions -> { name; package; dependency; message_type; enum_type; service; extension; options; source_code_info; public_dependency; weak_dependency; syntax } in
+        let constructor = fun name package dependency message_type enum_type service extension options source_code_info public_dependency weak_dependency syntax -> { name; package; dependency; message_type; enum_type; service; extension; options; source_code_info; public_dependency; weak_dependency; syntax } in
         let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: repeated (3, string, not_packed) ^:: repeated (4, (message (fun t -> DescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (5, (message (fun t -> EnumDescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (6, (message (fun t -> ServiceDescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (7, (message (fun t -> FieldDescriptorProto.from_proto_exn t)), not_packed) ^:: basic_opt (8, (message (fun t -> FileOptions.from_proto_exn t))) ^:: basic_opt (9, (message (fun t -> SourceCodeInfo.from_proto_exn t))) ^:: repeated (10, int32_int, not_packed) ^:: repeated (11, int32_int, not_packed) ^:: basic_opt (12, string) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and DescriptorProto : sig
       module rec ExtensionRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
-        val make : ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
+        val make: ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -651,7 +643,7 @@ end = struct
       and ReservedRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option }
-        val make : ?start:int -> ?end':int -> unit -> t
+        val make: ?start:int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -659,7 +651,7 @@ end = struct
       end
       val name': unit -> string
       type t = { name: string option; field: FieldDescriptorProto.t list; nested_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; extension_range: ExtensionRange.t list; extension: FieldDescriptorProto.t list; options: MessageOptions.t option; oneof_decl: OneofDescriptorProto.t list; reserved_range: ReservedRange.t list; reserved_name: string list }
-      val make : ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      val make: ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -668,7 +660,7 @@ end = struct
       module rec ExtensionRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
-        val make : ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
+        val make: ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -678,25 +670,21 @@ end = struct
         type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
         let make ?start ?end' ?options () = { start; end'; options }
         let to_proto' =
-          let apply = fun ~f:f' writer { start; end'; options } -> f' [] writer start end' options in
           let spec = Runtime'.Serialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, (message (fun t -> ExtensionRangeOptions.to_proto' t))) ^:: nil ) in
-          let serialize = Runtime'.Serialize.serialize [] spec in
-          fun writer t -> apply ~f:serialize writer t
+          let serialize = Runtime'.Serialize.serialize spec in
+          fun writer { start; end'; options } -> serialize writer start end' options
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
         let from_proto_exn =
-          let constructor = fun start end' options _extensions -> { start; end'; options } in
+          let constructor = fun start end' options -> { start; end'; options } in
           let spec = Runtime'.Deserialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, (message (fun t -> ExtensionRangeOptions.from_proto_exn t))) ^:: nil ) in
-          let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-          fun writer -> deserialize writer
-          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+          Runtime'.Deserialize.deserialize spec constructor
+        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       and ReservedRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option }
-        val make : ?start:int -> ?end':int -> unit -> t
+        val make: ?start:int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -706,67 +694,55 @@ end = struct
         type t = { start: int option; end': int option }
         let make ?start ?end' () = { start; end' }
         let to_proto' =
-          let apply = fun ~f:f' writer { start; end' } -> f' [] writer start end' in
           let spec = Runtime'.Serialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: nil ) in
-          let serialize = Runtime'.Serialize.serialize [] spec in
-          fun writer t -> apply ~f:serialize writer t
+          let serialize = Runtime'.Serialize.serialize spec in
+          fun writer { start; end' } -> serialize writer start end'
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
         let from_proto_exn =
-          let constructor = fun start end' _extensions -> { start; end' } in
+          let constructor = fun start end' -> { start; end' } in
           let spec = Runtime'.Deserialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: nil ) in
-          let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-          fun writer -> deserialize writer
-          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+          Runtime'.Deserialize.deserialize spec constructor
+        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       let name' () = "descriptor.google.protobuf.DescriptorProto"
       type t = { name: string option; field: FieldDescriptorProto.t list; nested_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; extension_range: ExtensionRange.t list; extension: FieldDescriptorProto.t list; options: MessageOptions.t option; oneof_decl: OneofDescriptorProto.t list; reserved_range: ReservedRange.t list; reserved_name: string list }
       let make ?name ?(field = []) ?(nested_type = []) ?(enum_type = []) ?(extension_range = []) ?(extension = []) ?options ?(oneof_decl = []) ?(reserved_range = []) ?(reserved_name = []) () = { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name }
       let to_proto' =
-        let apply = fun ~f:f' writer { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name } -> f' [] writer name field nested_type enum_type extension_range extension options oneof_decl reserved_range reserved_name in
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: repeated (2, (message (fun t -> FieldDescriptorProto.to_proto' t)), not_packed) ^:: repeated (3, (message (fun t -> DescriptorProto.to_proto' t)), not_packed) ^:: repeated (4, (message (fun t -> EnumDescriptorProto.to_proto' t)), not_packed) ^:: repeated (5, (message (fun t -> ExtensionRange.to_proto' t)), not_packed) ^:: repeated (6, (message (fun t -> FieldDescriptorProto.to_proto' t)), not_packed) ^:: basic_opt (7, (message (fun t -> MessageOptions.to_proto' t))) ^:: repeated (8, (message (fun t -> OneofDescriptorProto.to_proto' t)), not_packed) ^:: repeated (9, (message (fun t -> ReservedRange.to_proto' t)), not_packed) ^:: repeated (10, string, not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name } -> serialize writer name field nested_type enum_type extension_range extension options oneof_decl reserved_range reserved_name
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun name field nested_type enum_type extension_range extension options oneof_decl reserved_range reserved_name _extensions -> { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name } in
+        let constructor = fun name field nested_type enum_type extension_range extension options oneof_decl reserved_range reserved_name -> { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name } in
         let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: repeated (2, (message (fun t -> FieldDescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (3, (message (fun t -> DescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (4, (message (fun t -> EnumDescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (5, (message (fun t -> ExtensionRange.from_proto_exn t)), not_packed) ^:: repeated (6, (message (fun t -> FieldDescriptorProto.from_proto_exn t)), not_packed) ^:: basic_opt (7, (message (fun t -> MessageOptions.from_proto_exn t))) ^:: repeated (8, (message (fun t -> OneofDescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (9, (message (fun t -> ReservedRange.from_proto_exn t)), not_packed) ^:: repeated (10, string, not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and ExtensionRangeOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
     end = struct
       let name' () = "descriptor.google.protobuf.ExtensionRangeOptions"
-      type t = { extensions': Runtime'.Extensions.t; uninterpreted_option: UninterpretedOption.t list }
+      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { uninterpreted_option; extensions' }
       let to_proto' =
-        let apply = fun ~f:f' writer { uninterpreted_option; extensions' } -> f' extensions' writer uninterpreted_option in
-        let spec = Runtime'.Serialize.C.( repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [(1000, 536870912)] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let spec = Runtime'.Serialize.C.( repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { uninterpreted_option; extensions' } -> serialize writer uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
         let constructor = fun uninterpreted_option extensions' -> { uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [(1000, 536870912)] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        let spec = Runtime'.Deserialize.C.( repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and FieldDescriptorProto : sig
       module rec Type : sig
@@ -783,7 +759,7 @@ end = struct
       end
       val name': unit -> string
       type t = { name: string option; extendee: string option; number: int option; label: Label.t option; type': Type.t option; type_name: string option; default_value: string option; options: FieldOptions.t option; oneof_index: int option; json_name: string option; proto3_optional: bool option }
-      val make : ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
+      val make: ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -863,25 +839,21 @@ end = struct
       type t = { name: string option; extendee: string option; number: int option; label: Label.t option; type': Type.t option; type_name: string option; default_value: string option; options: FieldOptions.t option; oneof_index: int option; json_name: string option; proto3_optional: bool option }
       let make ?name ?extendee ?number ?label ?type' ?type_name ?default_value ?options ?oneof_index ?json_name ?proto3_optional () = { name; extendee; number; label; type'; type_name; default_value; options; oneof_index; json_name; proto3_optional }
       let to_proto' =
-        let apply = fun ~f:f' writer { name; extendee; number; label; type'; type_name; default_value; options; oneof_index; json_name; proto3_optional } -> f' [] writer name extendee number label type' type_name default_value options oneof_index json_name proto3_optional in
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, (enum Label.to_int)) ^:: basic_opt (5, (enum Type.to_int)) ^:: basic_opt (6, string) ^:: basic_opt (7, string) ^:: basic_opt (8, (message (fun t -> FieldOptions.to_proto' t))) ^:: basic_opt (9, int32_int) ^:: basic_opt (10, string) ^:: basic_opt (17, bool) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { name; extendee; number; label; type'; type_name; default_value; options; oneof_index; json_name; proto3_optional } -> serialize writer name extendee number label type' type_name default_value options oneof_index json_name proto3_optional
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun name extendee number label type' type_name default_value options oneof_index json_name proto3_optional _extensions -> { name; extendee; number; label; type'; type_name; default_value; options; oneof_index; json_name; proto3_optional } in
+        let constructor = fun name extendee number label type' type_name default_value options oneof_index json_name proto3_optional -> { name; extendee; number; label; type'; type_name; default_value; options; oneof_index; json_name; proto3_optional } in
         let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, (enum Label.from_int_exn)) ^:: basic_opt (5, (enum Type.from_int_exn)) ^:: basic_opt (6, string) ^:: basic_opt (7, string) ^:: basic_opt (8, (message (fun t -> FieldOptions.from_proto_exn t))) ^:: basic_opt (9, int32_int) ^:: basic_opt (10, string) ^:: basic_opt (17, bool) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and OneofDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; options: OneofOptions.t option }
-      val make : ?name:string -> ?options:OneofOptions.t -> unit -> t
+      val make: ?name:string -> ?options:OneofOptions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -891,26 +863,22 @@ end = struct
       type t = { name: string option; options: OneofOptions.t option }
       let make ?name ?options () = { name; options }
       let to_proto' =
-        let apply = fun ~f:f' writer { name; options } -> f' [] writer name options in
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, (message (fun t -> OneofOptions.to_proto' t))) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { name; options } -> serialize writer name options
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun name options _extensions -> { name; options } in
+        let constructor = fun name options -> { name; options } in
         let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, (message (fun t -> OneofOptions.from_proto_exn t))) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and EnumDescriptorProto : sig
       module rec EnumReservedRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option }
-        val make : ?start:int -> ?end':int -> unit -> t
+        val make: ?start:int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -918,7 +886,7 @@ end = struct
       end
       val name': unit -> string
       type t = { name: string option; value: EnumValueDescriptorProto.t list; options: EnumOptions.t option; reserved_range: EnumReservedRange.t list; reserved_name: string list }
-      val make : ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      val make: ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -927,7 +895,7 @@ end = struct
       module rec EnumReservedRange : sig
         val name': unit -> string
         type t = { start: int option; end': int option }
-        val make : ?start:int -> ?end':int -> unit -> t
+        val make: ?start:int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -937,44 +905,36 @@ end = struct
         type t = { start: int option; end': int option }
         let make ?start ?end' () = { start; end' }
         let to_proto' =
-          let apply = fun ~f:f' writer { start; end' } -> f' [] writer start end' in
           let spec = Runtime'.Serialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: nil ) in
-          let serialize = Runtime'.Serialize.serialize [] spec in
-          fun writer t -> apply ~f:serialize writer t
+          let serialize = Runtime'.Serialize.serialize spec in
+          fun writer { start; end' } -> serialize writer start end'
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
         let from_proto_exn =
-          let constructor = fun start end' _extensions -> { start; end' } in
+          let constructor = fun start end' -> { start; end' } in
           let spec = Runtime'.Deserialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: nil ) in
-          let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-          fun writer -> deserialize writer
-          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+          Runtime'.Deserialize.deserialize spec constructor
+        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       let name' () = "descriptor.google.protobuf.EnumDescriptorProto"
       type t = { name: string option; value: EnumValueDescriptorProto.t list; options: EnumOptions.t option; reserved_range: EnumReservedRange.t list; reserved_name: string list }
       let make ?name ?(value = []) ?options ?(reserved_range = []) ?(reserved_name = []) () = { name; value; options; reserved_range; reserved_name }
       let to_proto' =
-        let apply = fun ~f:f' writer { name; value; options; reserved_range; reserved_name } -> f' [] writer name value options reserved_range reserved_name in
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: repeated (2, (message (fun t -> EnumValueDescriptorProto.to_proto' t)), not_packed) ^:: basic_opt (3, (message (fun t -> EnumOptions.to_proto' t))) ^:: repeated (4, (message (fun t -> EnumReservedRange.to_proto' t)), not_packed) ^:: repeated (5, string, not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { name; value; options; reserved_range; reserved_name } -> serialize writer name value options reserved_range reserved_name
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun name value options reserved_range reserved_name _extensions -> { name; value; options; reserved_range; reserved_name } in
+        let constructor = fun name value options reserved_range reserved_name -> { name; value; options; reserved_range; reserved_name } in
         let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: repeated (2, (message (fun t -> EnumValueDescriptorProto.from_proto_exn t)), not_packed) ^:: basic_opt (3, (message (fun t -> EnumOptions.from_proto_exn t))) ^:: repeated (4, (message (fun t -> EnumReservedRange.from_proto_exn t)), not_packed) ^:: repeated (5, string, not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and EnumValueDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; number: int option; options: EnumValueOptions.t option }
-      val make : ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
+      val make: ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -984,25 +944,21 @@ end = struct
       type t = { name: string option; number: int option; options: EnumValueOptions.t option }
       let make ?name ?number ?options () = { name; number; options }
       let to_proto' =
-        let apply = fun ~f:f' writer { name; number; options } -> f' [] writer name number options in
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, (message (fun t -> EnumValueOptions.to_proto' t))) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { name; number; options } -> serialize writer name number options
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun name number options _extensions -> { name; number; options } in
+        let constructor = fun name number options -> { name; number; options } in
         let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, (message (fun t -> EnumValueOptions.from_proto_exn t))) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and ServiceDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; method': MethodDescriptorProto.t list; options: ServiceOptions.t option }
-      val make : ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
+      val make: ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1012,25 +968,21 @@ end = struct
       type t = { name: string option; method': MethodDescriptorProto.t list; options: ServiceOptions.t option }
       let make ?name ?(method' = []) ?options () = { name; method'; options }
       let to_proto' =
-        let apply = fun ~f:f' writer { name; method'; options } -> f' [] writer name method' options in
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: repeated (2, (message (fun t -> MethodDescriptorProto.to_proto' t)), not_packed) ^:: basic_opt (3, (message (fun t -> ServiceOptions.to_proto' t))) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { name; method'; options } -> serialize writer name method' options
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun name method' options _extensions -> { name; method'; options } in
+        let constructor = fun name method' options -> { name; method'; options } in
         let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: repeated (2, (message (fun t -> MethodDescriptorProto.from_proto_exn t)), not_packed) ^:: basic_opt (3, (message (fun t -> ServiceOptions.from_proto_exn t))) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and MethodDescriptorProto : sig
       val name': unit -> string
       type t = { name: string option; input_type: string option; output_type: string option; options: MethodOptions.t option; client_streaming: bool; server_streaming: bool }
-      val make : ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
+      val make: ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1040,20 +992,16 @@ end = struct
       type t = { name: string option; input_type: string option; output_type: string option; options: MethodOptions.t option; client_streaming: bool; server_streaming: bool }
       let make ?name ?input_type ?output_type ?options ?(client_streaming = false) ?(server_streaming = false) () = { name; input_type; output_type; options; client_streaming; server_streaming }
       let to_proto' =
-        let apply = fun ~f:f' writer { name; input_type; output_type; options; client_streaming; server_streaming } -> f' [] writer name input_type output_type options client_streaming server_streaming in
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, string) ^:: basic_opt (4, (message (fun t -> MethodOptions.to_proto' t))) ^:: basic (5, bool, Some (false)) ^:: basic (6, bool, Some (false)) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { name; input_type; output_type; options; client_streaming; server_streaming } -> serialize writer name input_type output_type options client_streaming server_streaming
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun name input_type output_type options client_streaming server_streaming _extensions -> { name; input_type; output_type; options; client_streaming; server_streaming } in
+        let constructor = fun name input_type output_type options client_streaming server_streaming -> { name; input_type; output_type; options; client_streaming; server_streaming } in
         let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, string) ^:: basic_opt (4, (message (fun t -> MethodOptions.from_proto_exn t))) ^:: basic (5, bool, Some (false)) ^:: basic (6, bool, Some (false)) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and FileOptions : sig
       module rec OptimizeMode : sig
@@ -1063,8 +1011,8 @@ end = struct
         val from_int_exn: int -> t
       end
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1091,51 +1039,43 @@ end = struct
         let from_int e = Runtime'.Result.catch (fun () -> from_int_exn e)
       end
       let name' () = "descriptor.google.protobuf.FileOptions"
-      type t = { extensions': Runtime'.Extensions.t; java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list }
+      type t = { java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?java_package ?java_outer_classname ?(optimize_for = OptimizeMode.SPEED) ?(java_multiple_files = false) ?go_package ?(cc_generic_services = false) ?(java_generic_services = false) ?(py_generic_services = false) ?java_generate_equals_and_hash ?(deprecated = false) ?(java_string_check_utf8 = false) ?(cc_enable_arenas = true) ?objc_class_prefix ?csharp_namespace ?swift_prefix ?php_class_prefix ?php_namespace ?(php_generic_services = false) ?php_metadata_namespace ?ruby_package ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { java_package; java_outer_classname; optimize_for; java_multiple_files; go_package; cc_generic_services; java_generic_services; py_generic_services; java_generate_equals_and_hash; deprecated; java_string_check_utf8; cc_enable_arenas; objc_class_prefix; csharp_namespace; swift_prefix; php_class_prefix; php_namespace; php_generic_services; php_metadata_namespace; ruby_package; uninterpreted_option; extensions' }
       let to_proto' =
-        let apply = fun ~f:f' writer { java_package; java_outer_classname; optimize_for; java_multiple_files; go_package; cc_generic_services; java_generic_services; py_generic_services; java_generate_equals_and_hash; deprecated; java_string_check_utf8; cc_enable_arenas; objc_class_prefix; csharp_namespace; swift_prefix; php_class_prefix; php_namespace; php_generic_services; php_metadata_namespace; ruby_package; uninterpreted_option; extensions' } -> f' extensions' writer java_package java_outer_classname optimize_for java_multiple_files go_package cc_generic_services java_generic_services py_generic_services java_generate_equals_and_hash deprecated java_string_check_utf8 cc_enable_arenas objc_class_prefix csharp_namespace swift_prefix php_class_prefix php_namespace php_generic_services php_metadata_namespace ruby_package uninterpreted_option in
-        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (8, string) ^:: basic (9, (enum OptimizeMode.to_int), Some (OptimizeMode.SPEED)) ^:: basic (10, bool, Some (false)) ^:: basic_opt (11, string) ^:: basic (16, bool, Some (false)) ^:: basic (17, bool, Some (false)) ^:: basic (18, bool, Some (false)) ^:: basic_opt (20, bool) ^:: basic (23, bool, Some (false)) ^:: basic (27, bool, Some (false)) ^:: basic (31, bool, Some (true)) ^:: basic_opt (36, string) ^:: basic_opt (37, string) ^:: basic_opt (39, string) ^:: basic_opt (40, string) ^:: basic_opt (41, string) ^:: basic (42, bool, Some (false)) ^:: basic_opt (44, string) ^:: basic_opt (45, string) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [(1000, 536870912)] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (8, string) ^:: basic (9, (enum OptimizeMode.to_int), Some (OptimizeMode.SPEED)) ^:: basic (10, bool, Some (false)) ^:: basic_opt (11, string) ^:: basic (16, bool, Some (false)) ^:: basic (17, bool, Some (false)) ^:: basic (18, bool, Some (false)) ^:: basic_opt (20, bool) ^:: basic (23, bool, Some (false)) ^:: basic (27, bool, Some (false)) ^:: basic (31, bool, Some (true)) ^:: basic_opt (36, string) ^:: basic_opt (37, string) ^:: basic_opt (39, string) ^:: basic_opt (40, string) ^:: basic_opt (41, string) ^:: basic (42, bool, Some (false)) ^:: basic_opt (44, string) ^:: basic_opt (45, string) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { java_package; java_outer_classname; optimize_for; java_multiple_files; go_package; cc_generic_services; java_generic_services; py_generic_services; java_generate_equals_and_hash; deprecated; java_string_check_utf8; cc_enable_arenas; objc_class_prefix; csharp_namespace; swift_prefix; php_class_prefix; php_namespace; php_generic_services; php_metadata_namespace; ruby_package; uninterpreted_option; extensions' } -> serialize writer java_package java_outer_classname optimize_for java_multiple_files go_package cc_generic_services java_generic_services py_generic_services java_generate_equals_and_hash deprecated java_string_check_utf8 cc_enable_arenas objc_class_prefix csharp_namespace swift_prefix php_class_prefix php_namespace php_generic_services php_metadata_namespace ruby_package uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
         let constructor = fun java_package java_outer_classname optimize_for java_multiple_files go_package cc_generic_services java_generic_services py_generic_services java_generate_equals_and_hash deprecated java_string_check_utf8 cc_enable_arenas objc_class_prefix csharp_namespace swift_prefix php_class_prefix php_namespace php_generic_services php_metadata_namespace ruby_package uninterpreted_option extensions' -> { java_package; java_outer_classname; optimize_for; java_multiple_files; go_package; cc_generic_services; java_generic_services; py_generic_services; java_generate_equals_and_hash; deprecated; java_string_check_utf8; cc_enable_arenas; objc_class_prefix; csharp_namespace; swift_prefix; php_class_prefix; php_namespace; php_generic_services; php_metadata_namespace; ruby_package; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (8, string) ^:: basic (9, (enum OptimizeMode.from_int_exn), Some (OptimizeMode.SPEED)) ^:: basic (10, bool, Some (false)) ^:: basic_opt (11, string) ^:: basic (16, bool, Some (false)) ^:: basic (17, bool, Some (false)) ^:: basic (18, bool, Some (false)) ^:: basic_opt (20, bool) ^:: basic (23, bool, Some (false)) ^:: basic (27, bool, Some (false)) ^:: basic (31, bool, Some (true)) ^:: basic_opt (36, string) ^:: basic_opt (37, string) ^:: basic_opt (39, string) ^:: basic_opt (40, string) ^:: basic_opt (41, string) ^:: basic (42, bool, Some (false)) ^:: basic_opt (44, string) ^:: basic_opt (45, string) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [(1000, 536870912)] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (8, string) ^:: basic (9, (enum OptimizeMode.from_int_exn), Some (OptimizeMode.SPEED)) ^:: basic (10, bool, Some (false)) ^:: basic_opt (11, string) ^:: basic (16, bool, Some (false)) ^:: basic (17, bool, Some (false)) ^:: basic (18, bool, Some (false)) ^:: basic_opt (20, bool) ^:: basic (23, bool, Some (false)) ^:: basic (27, bool, Some (false)) ^:: basic (31, bool, Some (true)) ^:: basic_opt (36, string) ^:: basic_opt (37, string) ^:: basic_opt (39, string) ^:: basic_opt (40, string) ^:: basic_opt (41, string) ^:: basic (42, bool, Some (false)) ^:: basic_opt (44, string) ^:: basic_opt (45, string) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and MessageOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
     end = struct
       let name' () = "descriptor.google.protobuf.MessageOptions"
-      type t = { extensions': Runtime'.Extensions.t; message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list }
+      type t = { message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(message_set_wire_format = false) ?(no_standard_descriptor_accessor = false) ?(deprecated = false) ?map_entry ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { message_set_wire_format; no_standard_descriptor_accessor; deprecated; map_entry; uninterpreted_option; extensions' }
       let to_proto' =
-        let apply = fun ~f:f' writer { message_set_wire_format; no_standard_descriptor_accessor; deprecated; map_entry; uninterpreted_option; extensions' } -> f' extensions' writer message_set_wire_format no_standard_descriptor_accessor deprecated map_entry uninterpreted_option in
-        let spec = Runtime'.Serialize.C.( basic (1, bool, Some (false)) ^:: basic (2, bool, Some (false)) ^:: basic (3, bool, Some (false)) ^:: basic_opt (7, bool) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [(1000, 536870912)] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let spec = Runtime'.Serialize.C.( basic (1, bool, Some (false)) ^:: basic (2, bool, Some (false)) ^:: basic (3, bool, Some (false)) ^:: basic_opt (7, bool) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { message_set_wire_format; no_standard_descriptor_accessor; deprecated; map_entry; uninterpreted_option; extensions' } -> serialize writer message_set_wire_format no_standard_descriptor_accessor deprecated map_entry uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
         let constructor = fun message_set_wire_format no_standard_descriptor_accessor deprecated map_entry uninterpreted_option extensions' -> { message_set_wire_format; no_standard_descriptor_accessor; deprecated; map_entry; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ^:: basic (2, bool, Some (false)) ^:: basic (3, bool, Some (false)) ^:: basic_opt (7, bool) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [(1000, 536870912)] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        let spec = Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ^:: basic (2, bool, Some (false)) ^:: basic (3, bool, Some (false)) ^:: basic_opt (7, bool) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and FieldOptions : sig
       module rec CType : sig
@@ -1151,8 +1091,8 @@ end = struct
         val from_int_exn: int -> t
       end
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1199,135 +1139,115 @@ end = struct
         let from_int e = Runtime'.Result.catch (fun () -> from_int_exn e)
       end
       let name' () = "descriptor.google.protobuf.FieldOptions"
-      type t = { extensions': Runtime'.Extensions.t; ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list }
+      type t = { ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(ctype = CType.STRING) ?packed ?(deprecated = false) ?(lazy' = false) ?(jstype = JSType.JS_NORMAL) ?(weak = false) ?(unverified_lazy = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { ctype; packed; deprecated; lazy'; jstype; weak; unverified_lazy; uninterpreted_option; extensions' }
       let to_proto' =
-        let apply = fun ~f:f' writer { ctype; packed; deprecated; lazy'; jstype; weak; unverified_lazy; uninterpreted_option; extensions' } -> f' extensions' writer ctype packed deprecated lazy' jstype weak unverified_lazy uninterpreted_option in
-        let spec = Runtime'.Serialize.C.( basic (1, (enum CType.to_int), Some (CType.STRING)) ^:: basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: basic (5, bool, Some (false)) ^:: basic (6, (enum JSType.to_int), Some (JSType.JS_NORMAL)) ^:: basic (10, bool, Some (false)) ^:: basic (15, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [(1000, 536870912)] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let spec = Runtime'.Serialize.C.( basic (1, (enum CType.to_int), Some (CType.STRING)) ^:: basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: basic (5, bool, Some (false)) ^:: basic (6, (enum JSType.to_int), Some (JSType.JS_NORMAL)) ^:: basic (10, bool, Some (false)) ^:: basic (15, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { ctype; packed; deprecated; lazy'; jstype; weak; unverified_lazy; uninterpreted_option; extensions' } -> serialize writer ctype packed deprecated lazy' jstype weak unverified_lazy uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
         let constructor = fun ctype packed deprecated lazy' jstype weak unverified_lazy uninterpreted_option extensions' -> { ctype; packed; deprecated; lazy'; jstype; weak; unverified_lazy; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (1, (enum CType.from_int_exn), Some (CType.STRING)) ^:: basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: basic (5, bool, Some (false)) ^:: basic (6, (enum JSType.from_int_exn), Some (JSType.JS_NORMAL)) ^:: basic (10, bool, Some (false)) ^:: basic (15, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [(1000, 536870912)] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        let spec = Runtime'.Deserialize.C.( basic (1, (enum CType.from_int_exn), Some (CType.STRING)) ^:: basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: basic (5, bool, Some (false)) ^:: basic (6, (enum JSType.from_int_exn), Some (JSType.JS_NORMAL)) ^:: basic (10, bool, Some (false)) ^:: basic (15, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and OneofOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
     end = struct
       let name' () = "descriptor.google.protobuf.OneofOptions"
-      type t = { extensions': Runtime'.Extensions.t; uninterpreted_option: UninterpretedOption.t list }
+      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { uninterpreted_option; extensions' }
       let to_proto' =
-        let apply = fun ~f:f' writer { uninterpreted_option; extensions' } -> f' extensions' writer uninterpreted_option in
-        let spec = Runtime'.Serialize.C.( repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [(1000, 536870912)] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let spec = Runtime'.Serialize.C.( repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { uninterpreted_option; extensions' } -> serialize writer uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
         let constructor = fun uninterpreted_option extensions' -> { uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [(1000, 536870912)] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        let spec = Runtime'.Deserialize.C.( repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and EnumOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
     end = struct
       let name' () = "descriptor.google.protobuf.EnumOptions"
-      type t = { extensions': Runtime'.Extensions.t; allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
+      type t = { allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?allow_alias ?(deprecated = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { allow_alias; deprecated; uninterpreted_option; extensions' }
       let to_proto' =
-        let apply = fun ~f:f' writer { allow_alias; deprecated; uninterpreted_option; extensions' } -> f' extensions' writer allow_alias deprecated uninterpreted_option in
-        let spec = Runtime'.Serialize.C.( basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [(1000, 536870912)] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let spec = Runtime'.Serialize.C.( basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { allow_alias; deprecated; uninterpreted_option; extensions' } -> serialize writer allow_alias deprecated uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
         let constructor = fun allow_alias deprecated uninterpreted_option extensions' -> { allow_alias; deprecated; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [(1000, 536870912)] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        let spec = Runtime'.Deserialize.C.( basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and EnumValueOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
     end = struct
       let name' () = "descriptor.google.protobuf.EnumValueOptions"
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
+      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(deprecated = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { deprecated; uninterpreted_option; extensions' }
       let to_proto' =
-        let apply = fun ~f:f' writer { deprecated; uninterpreted_option; extensions' } -> f' extensions' writer deprecated uninterpreted_option in
-        let spec = Runtime'.Serialize.C.( basic (1, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [(1000, 536870912)] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let spec = Runtime'.Serialize.C.( basic (1, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { deprecated; uninterpreted_option; extensions' } -> serialize writer deprecated uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
         let constructor = fun deprecated uninterpreted_option extensions' -> { deprecated; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [(1000, 536870912)] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        let spec = Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and ServiceOptions : sig
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
     end = struct
       let name' () = "descriptor.google.protobuf.ServiceOptions"
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; uninterpreted_option: UninterpretedOption.t list }
+      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(deprecated = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { deprecated; uninterpreted_option; extensions' }
       let to_proto' =
-        let apply = fun ~f:f' writer { deprecated; uninterpreted_option; extensions' } -> f' extensions' writer deprecated uninterpreted_option in
-        let spec = Runtime'.Serialize.C.( basic (33, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [(1000, 536870912)] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let spec = Runtime'.Serialize.C.( basic (33, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { deprecated; uninterpreted_option; extensions' } -> serialize writer deprecated uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
         let constructor = fun deprecated uninterpreted_option extensions' -> { deprecated; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (33, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [(1000, 536870912)] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        let spec = Runtime'.Deserialize.C.( basic (33, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and MethodOptions : sig
       module rec IdempotencyLevel : sig
@@ -1337,8 +1257,8 @@ end = struct
         val from_int_exn: int -> t
       end
       val name': unit -> string
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list }
-      val make : ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      type t = { deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      val make: ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1365,29 +1285,25 @@ end = struct
         let from_int e = Runtime'.Result.catch (fun () -> from_int_exn e)
       end
       let name' () = "descriptor.google.protobuf.MethodOptions"
-      type t = { extensions': Runtime'.Extensions.t; deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list }
+      type t = { deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(deprecated = false) ?(idempotency_level = IdempotencyLevel.IDEMPOTENCY_UNKNOWN) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { deprecated; idempotency_level; uninterpreted_option; extensions' }
       let to_proto' =
-        let apply = fun ~f:f' writer { deprecated; idempotency_level; uninterpreted_option; extensions' } -> f' extensions' writer deprecated idempotency_level uninterpreted_option in
-        let spec = Runtime'.Serialize.C.( basic (33, bool, Some (false)) ^:: basic (34, (enum IdempotencyLevel.to_int), Some (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [(1000, 536870912)] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let spec = Runtime'.Serialize.C.( basic (33, bool, Some (false)) ^:: basic (34, (enum IdempotencyLevel.to_int), Some (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { deprecated; idempotency_level; uninterpreted_option; extensions' } -> serialize writer deprecated idempotency_level uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
         let constructor = fun deprecated idempotency_level uninterpreted_option extensions' -> { deprecated; idempotency_level; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (33, bool, Some (false)) ^:: basic (34, (enum IdempotencyLevel.from_int_exn), Some (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [(1000, 536870912)] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        let spec = Runtime'.Deserialize.C.( basic (33, bool, Some (false)) ^:: basic (34, (enum IdempotencyLevel.from_int_exn), Some (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and UninterpretedOption : sig
       module rec NamePart : sig
         val name': unit -> string
         type t = { name_part: string; is_extension: bool }
-        val make : name_part:string -> is_extension:bool -> unit -> t
+        val make: name_part:string -> is_extension:bool -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1395,7 +1311,7 @@ end = struct
       end
       val name': unit -> string
       type t = { name: NamePart.t list; identifier_value: string option; positive_int_value: int option; negative_int_value: int option; double_value: float option; string_value: bytes option; aggregate_value: string option }
-      val make : ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
+      val make: ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1404,7 +1320,7 @@ end = struct
       module rec NamePart : sig
         val name': unit -> string
         type t = { name_part: string; is_extension: bool }
-        val make : name_part:string -> is_extension:bool -> unit -> t
+        val make: name_part:string -> is_extension:bool -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1414,45 +1330,37 @@ end = struct
         type t = { name_part: string; is_extension: bool }
         let make ~name_part ~is_extension () = { name_part; is_extension }
         let to_proto' =
-          let apply = fun ~f:f' writer { name_part; is_extension } -> f' [] writer name_part is_extension in
           let spec = Runtime'.Serialize.C.( basic (1, string, None) ^:: basic (2, bool, None) ^:: nil ) in
-          let serialize = Runtime'.Serialize.serialize [] spec in
-          fun writer t -> apply ~f:serialize writer t
+          let serialize = Runtime'.Serialize.serialize spec in
+          fun writer { name_part; is_extension } -> serialize writer name_part is_extension
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
         let from_proto_exn =
-          let constructor = fun name_part is_extension _extensions -> { name_part; is_extension } in
+          let constructor = fun name_part is_extension -> { name_part; is_extension } in
           let spec = Runtime'.Deserialize.C.( basic (1, string, None) ^:: basic (2, bool, None) ^:: nil ) in
-          let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-          fun writer -> deserialize writer
-          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+          Runtime'.Deserialize.deserialize spec constructor
+        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       let name' () = "descriptor.google.protobuf.UninterpretedOption"
       type t = { name: NamePart.t list; identifier_value: string option; positive_int_value: int option; negative_int_value: int option; double_value: float option; string_value: bytes option; aggregate_value: string option }
       let make ?(name = []) ?identifier_value ?positive_int_value ?negative_int_value ?double_value ?string_value ?aggregate_value () = { name; identifier_value; positive_int_value; negative_int_value; double_value; string_value; aggregate_value }
       let to_proto' =
-        let apply = fun ~f:f' writer { name; identifier_value; positive_int_value; negative_int_value; double_value; string_value; aggregate_value } -> f' [] writer name identifier_value positive_int_value negative_int_value double_value string_value aggregate_value in
         let spec = Runtime'.Serialize.C.( repeated (2, (message (fun t -> NamePart.to_proto' t)), not_packed) ^:: basic_opt (3, string) ^:: basic_opt (4, uint64_int) ^:: basic_opt (5, int64_int) ^:: basic_opt (6, double) ^:: basic_opt (7, bytes) ^:: basic_opt (8, string) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        fun writer { name; identifier_value; positive_int_value; negative_int_value; double_value; string_value; aggregate_value } -> serialize writer name identifier_value positive_int_value negative_int_value double_value string_value aggregate_value
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun name identifier_value positive_int_value negative_int_value double_value string_value aggregate_value _extensions -> { name; identifier_value; positive_int_value; negative_int_value; double_value; string_value; aggregate_value } in
+        let constructor = fun name identifier_value positive_int_value negative_int_value double_value string_value aggregate_value -> { name; identifier_value; positive_int_value; negative_int_value; double_value; string_value; aggregate_value } in
         let spec = Runtime'.Deserialize.C.( repeated (2, (message (fun t -> NamePart.from_proto_exn t)), not_packed) ^:: basic_opt (3, string) ^:: basic_opt (4, uint64_int) ^:: basic_opt (5, int64_int) ^:: basic_opt (6, double) ^:: basic_opt (7, bytes) ^:: basic_opt (8, string) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and SourceCodeInfo : sig
       module rec Location : sig
         val name': unit -> string
         type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
-        val make : ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
+        val make: ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1460,7 +1368,7 @@ end = struct
       end
       val name': unit -> string
       type t = Location.t list
-      val make : ?location:Location.t list -> unit -> t
+      val make: ?location:Location.t list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1469,7 +1377,7 @@ end = struct
       module rec Location : sig
         val name': unit -> string
         type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
-        val make : ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
+        val make: ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1479,45 +1387,37 @@ end = struct
         type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
         let make ?(path = []) ?(span = []) ?leading_comments ?trailing_comments ?(leading_detached_comments = []) () = { path; span; leading_comments; trailing_comments; leading_detached_comments }
         let to_proto' =
-          let apply = fun ~f:f' writer { path; span; leading_comments; trailing_comments; leading_detached_comments } -> f' [] writer path span leading_comments trailing_comments leading_detached_comments in
           let spec = Runtime'.Serialize.C.( repeated (1, int32_int, packed) ^:: repeated (2, int32_int, packed) ^:: basic_opt (3, string) ^:: basic_opt (4, string) ^:: repeated (6, string, not_packed) ^:: nil ) in
-          let serialize = Runtime'.Serialize.serialize [] spec in
-          fun writer t -> apply ~f:serialize writer t
+          let serialize = Runtime'.Serialize.serialize spec in
+          fun writer { path; span; leading_comments; trailing_comments; leading_detached_comments } -> serialize writer path span leading_comments trailing_comments leading_detached_comments
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
         let from_proto_exn =
-          let constructor = fun path span leading_comments trailing_comments leading_detached_comments _extensions -> { path; span; leading_comments; trailing_comments; leading_detached_comments } in
+          let constructor = fun path span leading_comments trailing_comments leading_detached_comments -> { path; span; leading_comments; trailing_comments; leading_detached_comments } in
           let spec = Runtime'.Deserialize.C.( repeated (1, int32_int, packed) ^:: repeated (2, int32_int, packed) ^:: basic_opt (3, string) ^:: basic_opt (4, string) ^:: repeated (6, string, not_packed) ^:: nil ) in
-          let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-          fun writer -> deserialize writer
-          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+          Runtime'.Deserialize.deserialize spec constructor
+        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       let name' () = "descriptor.google.protobuf.SourceCodeInfo"
       type t = Location.t list
       let make ?(location = []) () = location
       let to_proto' =
-        let apply = fun ~f:f' writer location -> f' [] writer location in
         let spec = Runtime'.Serialize.C.( repeated (1, (message (fun t -> Location.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        serialize
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun location _extensions -> location in
+        let constructor = fun location -> location in
         let spec = Runtime'.Deserialize.C.( repeated (1, (message (fun t -> Location.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
     and GeneratedCodeInfo : sig
       module rec Annotation : sig
         val name': unit -> string
         type t = { path: int list; source_file: string option; begin': int option; end': int option }
-        val make : ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
+        val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1525,7 +1425,7 @@ end = struct
       end
       val name': unit -> string
       type t = Annotation.t list
-      val make : ?annotation:Annotation.t list -> unit -> t
+      val make: ?annotation:Annotation.t list -> unit -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1534,7 +1434,7 @@ end = struct
       module rec Annotation : sig
         val name': unit -> string
         type t = { path: int list; source_file: string option; begin': int option; end': int option }
-        val make : ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
+        val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1544,39 +1444,31 @@ end = struct
         type t = { path: int list; source_file: string option; begin': int option; end': int option }
         let make ?(path = []) ?source_file ?begin' ?end' () = { path; source_file; begin'; end' }
         let to_proto' =
-          let apply = fun ~f:f' writer { path; source_file; begin'; end' } -> f' [] writer path source_file begin' end' in
           let spec = Runtime'.Serialize.C.( repeated (1, int32_int, packed) ^:: basic_opt (2, string) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, int32_int) ^:: nil ) in
-          let serialize = Runtime'.Serialize.serialize [] spec in
-          fun writer t -> apply ~f:serialize writer t
+          let serialize = Runtime'.Serialize.serialize spec in
+          fun writer { path; source_file; begin'; end' } -> serialize writer path source_file begin' end'
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
         let from_proto_exn =
-          let constructor = fun path source_file begin' end' _extensions -> { path; source_file; begin'; end' } in
+          let constructor = fun path source_file begin' end' -> { path; source_file; begin'; end' } in
           let spec = Runtime'.Deserialize.C.( repeated (1, int32_int, packed) ^:: basic_opt (2, string) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, int32_int) ^:: nil ) in
-          let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-          fun writer -> deserialize writer
-          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+          Runtime'.Deserialize.deserialize spec constructor
+        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       let name' () = "descriptor.google.protobuf.GeneratedCodeInfo"
       type t = Annotation.t list
       let make ?(annotation = []) () = annotation
       let to_proto' =
-        let apply = fun ~f:f' writer annotation -> f' [] writer annotation in
         let spec = Runtime'.Serialize.C.( repeated (1, (message (fun t -> Annotation.to_proto' t)), not_packed) ^:: nil ) in
-        let serialize = Runtime'.Serialize.serialize [] spec in
-        fun writer t -> apply ~f:serialize writer t
+        let serialize = Runtime'.Serialize.serialize spec in
+        serialize
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
       let from_proto_exn =
-        let constructor = fun annotation _extensions -> annotation in
+        let constructor = fun annotation -> annotation in
         let spec = Runtime'.Deserialize.C.( repeated (1, (message (fun t -> Annotation.from_proto_exn t)), not_packed) ^:: nil ) in
-        let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-        fun writer -> deserialize writer
-        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+        Runtime'.Deserialize.deserialize spec constructor
+      let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
   end
 end

--- a/src/spec/descriptor.ml
+++ b/src/spec/descriptor.ml
@@ -22,8 +22,9 @@ module rec Google : sig
   module rec Protobuf : sig
     module rec FileDescriptorSet : sig
       val name': unit -> string
-      type t = FileDescriptorProto.t list
+      type t = (FileDescriptorProto.t list)
       val make: ?file:FileDescriptorProto.t list -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -33,6 +34,7 @@ module rec Google : sig
       val name': unit -> string
       type t = { name: string option; package: string option; dependency: string list; message_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; service: ServiceDescriptorProto.t list; extension: FieldDescriptorProto.t list; options: FileOptions.t option; source_code_info: SourceCodeInfo.t option; public_dependency: int list; weak_dependency: int list; syntax: string option }
       val make: ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -43,6 +45,7 @@ module rec Google : sig
         val name': unit -> string
         type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
         val make: ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -52,6 +55,7 @@ module rec Google : sig
         val name': unit -> string
         type t = { start: int option; end': int option }
         val make: ?start:int -> ?end':int -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -60,6 +64,7 @@ module rec Google : sig
       val name': unit -> string
       type t = { name: string option; field: FieldDescriptorProto.t list; nested_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; extension_range: ExtensionRange.t list; extension: FieldDescriptorProto.t list; options: MessageOptions.t option; oneof_decl: OneofDescriptorProto.t list; reserved_range: ReservedRange.t list; reserved_name: string list }
       val make: ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -69,6 +74,7 @@ module rec Google : sig
       val name': unit -> string
       type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -90,6 +96,7 @@ module rec Google : sig
       val name': unit -> string
       type t = { name: string option; extendee: string option; number: int option; label: Label.t option; type': Type.t option; type_name: string option; default_value: string option; options: FieldOptions.t option; oneof_index: int option; json_name: string option; proto3_optional: bool option }
       val make: ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -99,6 +106,7 @@ module rec Google : sig
       val name': unit -> string
       type t = { name: string option; options: OneofOptions.t option }
       val make: ?name:string -> ?options:OneofOptions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -109,6 +117,7 @@ module rec Google : sig
         val name': unit -> string
         type t = { start: int option; end': int option }
         val make: ?start:int -> ?end':int -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -117,6 +126,7 @@ module rec Google : sig
       val name': unit -> string
       type t = { name: string option; value: EnumValueDescriptorProto.t list; options: EnumOptions.t option; reserved_range: EnumReservedRange.t list; reserved_name: string list }
       val make: ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -126,6 +136,7 @@ module rec Google : sig
       val name': unit -> string
       type t = { name: string option; number: int option; options: EnumValueOptions.t option }
       val make: ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -135,6 +146,7 @@ module rec Google : sig
       val name': unit -> string
       type t = { name: string option; method': MethodDescriptorProto.t list; options: ServiceOptions.t option }
       val make: ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -144,6 +156,7 @@ module rec Google : sig
       val name': unit -> string
       type t = { name: string option; input_type: string option; output_type: string option; options: MethodOptions.t option; client_streaming: bool; server_streaming: bool }
       val make: ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -159,6 +172,7 @@ module rec Google : sig
       val name': unit -> string
       type t = { java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -168,6 +182,7 @@ module rec Google : sig
       val name': unit -> string
       type t = { message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -189,6 +204,7 @@ module rec Google : sig
       val name': unit -> string
       type t = { ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -198,6 +214,7 @@ module rec Google : sig
       val name': unit -> string
       type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -207,6 +224,7 @@ module rec Google : sig
       val name': unit -> string
       type t = { allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -216,6 +234,7 @@ module rec Google : sig
       val name': unit -> string
       type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -225,6 +244,7 @@ module rec Google : sig
       val name': unit -> string
       type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -240,6 +260,7 @@ module rec Google : sig
       val name': unit -> string
       type t = { deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -250,6 +271,7 @@ module rec Google : sig
         val name': unit -> string
         type t = { name_part: string; is_extension: bool }
         val make: name_part:string -> is_extension:bool -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -258,6 +280,7 @@ module rec Google : sig
       val name': unit -> string
       type t = { name: NamePart.t list; identifier_value: string option; positive_int_value: int option; negative_int_value: int option; double_value: float option; string_value: bytes option; aggregate_value: string option }
       val make: ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -268,14 +291,16 @@ module rec Google : sig
         val name': unit -> string
         type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
         val make: ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
       end
       val name': unit -> string
-      type t = Location.t list
+      type t = (Location.t list)
       val make: ?location:Location.t list -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -286,14 +311,16 @@ module rec Google : sig
         val name': unit -> string
         type t = { path: int list; source_file: string option; begin': int option; end': int option }
         val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
       end
       val name': unit -> string
-      type t = Annotation.t list
+      type t = (Annotation.t list)
       val make: ?annotation:Annotation.t list -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -304,8 +331,9 @@ end = struct
   module rec Protobuf : sig
     module rec FileDescriptorSet : sig
       val name': unit -> string
-      type t = FileDescriptorProto.t list
+      type t = (FileDescriptorProto.t list)
       val make: ?file:FileDescriptorProto.t list -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -315,6 +343,7 @@ end = struct
       val name': unit -> string
       type t = { name: string option; package: string option; dependency: string list; message_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; service: ServiceDescriptorProto.t list; extension: FieldDescriptorProto.t list; options: FileOptions.t option; source_code_info: SourceCodeInfo.t option; public_dependency: int list; weak_dependency: int list; syntax: string option }
       val make: ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -325,6 +354,7 @@ end = struct
         val name': unit -> string
         type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
         val make: ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -334,6 +364,7 @@ end = struct
         val name': unit -> string
         type t = { start: int option; end': int option }
         val make: ?start:int -> ?end':int -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -342,6 +373,7 @@ end = struct
       val name': unit -> string
       type t = { name: string option; field: FieldDescriptorProto.t list; nested_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; extension_range: ExtensionRange.t list; extension: FieldDescriptorProto.t list; options: MessageOptions.t option; oneof_decl: OneofDescriptorProto.t list; reserved_range: ReservedRange.t list; reserved_name: string list }
       val make: ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -351,6 +383,7 @@ end = struct
       val name': unit -> string
       type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -372,6 +405,7 @@ end = struct
       val name': unit -> string
       type t = { name: string option; extendee: string option; number: int option; label: Label.t option; type': Type.t option; type_name: string option; default_value: string option; options: FieldOptions.t option; oneof_index: int option; json_name: string option; proto3_optional: bool option }
       val make: ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -381,6 +415,7 @@ end = struct
       val name': unit -> string
       type t = { name: string option; options: OneofOptions.t option }
       val make: ?name:string -> ?options:OneofOptions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -391,6 +426,7 @@ end = struct
         val name': unit -> string
         type t = { start: int option; end': int option }
         val make: ?start:int -> ?end':int -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -399,6 +435,7 @@ end = struct
       val name': unit -> string
       type t = { name: string option; value: EnumValueDescriptorProto.t list; options: EnumOptions.t option; reserved_range: EnumReservedRange.t list; reserved_name: string list }
       val make: ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -408,6 +445,7 @@ end = struct
       val name': unit -> string
       type t = { name: string option; number: int option; options: EnumValueOptions.t option }
       val make: ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -417,6 +455,7 @@ end = struct
       val name': unit -> string
       type t = { name: string option; method': MethodDescriptorProto.t list; options: ServiceOptions.t option }
       val make: ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -426,6 +465,7 @@ end = struct
       val name': unit -> string
       type t = { name: string option; input_type: string option; output_type: string option; options: MethodOptions.t option; client_streaming: bool; server_streaming: bool }
       val make: ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -441,6 +481,7 @@ end = struct
       val name': unit -> string
       type t = { java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -450,6 +491,7 @@ end = struct
       val name': unit -> string
       type t = { message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -471,6 +513,7 @@ end = struct
       val name': unit -> string
       type t = { ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -480,6 +523,7 @@ end = struct
       val name': unit -> string
       type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -489,6 +533,7 @@ end = struct
       val name': unit -> string
       type t = { allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -498,6 +543,7 @@ end = struct
       val name': unit -> string
       type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -507,6 +553,7 @@ end = struct
       val name': unit -> string
       type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -522,6 +569,7 @@ end = struct
       val name': unit -> string
       type t = { deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -532,6 +580,7 @@ end = struct
         val name': unit -> string
         type t = { name_part: string; is_extension: bool }
         val make: name_part:string -> is_extension:bool -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -540,6 +589,7 @@ end = struct
       val name': unit -> string
       type t = { name: NamePart.t list; identifier_value: string option; positive_int_value: int option; negative_int_value: int option; double_value: float option; string_value: bytes option; aggregate_value: string option }
       val make: ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -550,14 +600,16 @@ end = struct
         val name': unit -> string
         type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
         val make: ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
       end
       val name': unit -> string
-      type t = Location.t list
+      type t = (Location.t list)
       val make: ?location:Location.t list -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -568,14 +620,16 @@ end = struct
         val name': unit -> string
         type t = { path: int list; source_file: string option; begin': int option; end': int option }
         val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
       end
       val name': unit -> string
-      type t = Annotation.t list
+      type t = (Annotation.t list)
       val make: ?annotation:Annotation.t list -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -584,25 +638,30 @@ end = struct
   end = struct
     module rec FileDescriptorSet : sig
       val name': unit -> string
-      type t = FileDescriptorProto.t list
+      type t = (FileDescriptorProto.t list)
       val make: ?file:FileDescriptorProto.t list -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
     end = struct
       let name' () = "descriptor.google.protobuf.FileDescriptorSet"
-      type t = FileDescriptorProto.t list
-      let make ?(file = []) () = file
+      type t = (FileDescriptorProto.t list)
+      let make ?(file = []) () = (file)
+      let merge = (fun (t1_file) (t2_file) ->
+        let file = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (1, (message ((fun writer -> FileDescriptorProto.from_proto_exn writer), FileDescriptorProto.merge)), not_packed) ) t1_file t2_file in
+
+        (file))
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( repeated (1, (message (fun t -> FileDescriptorProto.to_proto' t)), not_packed) ^:: nil ) in
+        let spec = Runtime'.Serialize.C.( repeated (1, (message FileDescriptorProto.to_proto'), not_packed) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
         serialize
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
-        let constructor = fun file -> file in
-        let spec = Runtime'.Deserialize.C.( repeated (1, (message (fun t -> FileDescriptorProto.from_proto_exn t)), not_packed) ^:: nil ) in
+        let constructor = fun file -> (file) in
+        let spec = Runtime'.Deserialize.C.( repeated (1, (message ((fun writer -> FileDescriptorProto.from_proto_exn writer), FileDescriptorProto.merge)), not_packed) ^:: nil ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -610,6 +669,7 @@ end = struct
       val name': unit -> string
       type t = { name: string option; package: string option; dependency: string list; message_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; service: ServiceDescriptorProto.t list; extension: FieldDescriptorProto.t list; options: FileOptions.t option; source_code_info: SourceCodeInfo.t option; public_dependency: int list; weak_dependency: int list; syntax: string option }
       val make: ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -618,15 +678,41 @@ end = struct
       let name' () = "descriptor.google.protobuf.FileDescriptorProto"
       type t = { name: string option; package: string option; dependency: string list; message_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; service: ServiceDescriptorProto.t list; extension: FieldDescriptorProto.t list; options: FileOptions.t option; source_code_info: SourceCodeInfo.t option; public_dependency: int list; weak_dependency: int list; syntax: string option }
       let make ?name ?package ?(dependency = []) ?(message_type = []) ?(enum_type = []) ?(service = []) ?(extension = []) ?options ?source_code_info ?(public_dependency = []) ?(weak_dependency = []) ?syntax () = { name; package; dependency; message_type; enum_type; service; extension; options; source_code_info; public_dependency; weak_dependency; syntax }
+      let merge = (fun t1 t2 ->
+        let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name in
+
+        let package = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, string) ) t1.package t2.package in
+
+        let dependency = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (3, string, not_packed) ) t1.dependency t2.dependency in
+
+        let message_type = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (4, (message ((fun writer -> DescriptorProto.from_proto_exn writer), DescriptorProto.merge)), not_packed) ) t1.message_type t2.message_type in
+
+        let enum_type = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (5, (message ((fun writer -> EnumDescriptorProto.from_proto_exn writer), EnumDescriptorProto.merge)), not_packed) ) t1.enum_type t2.enum_type in
+
+        let service = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (6, (message ((fun writer -> ServiceDescriptorProto.from_proto_exn writer), ServiceDescriptorProto.merge)), not_packed) ) t1.service t2.service in
+
+        let extension = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (7, (message ((fun writer -> FieldDescriptorProto.from_proto_exn writer), FieldDescriptorProto.merge)), not_packed) ) t1.extension t2.extension in
+
+        let options = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (8, (message ((fun writer -> FileOptions.from_proto_exn writer), FileOptions.merge))) ) t1.options t2.options in
+
+        let source_code_info = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (9, (message ((fun writer -> SourceCodeInfo.from_proto_exn writer), SourceCodeInfo.merge))) ) t1.source_code_info t2.source_code_info in
+
+        let public_dependency = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (10, int32_int, not_packed) ) t1.public_dependency t2.public_dependency in
+
+        let weak_dependency = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (11, int32_int, not_packed) ) t1.weak_dependency t2.weak_dependency in
+
+        let syntax = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (12, string) ) t1.syntax t2.syntax in
+
+        { name; package; dependency; message_type; enum_type; service; extension; options; source_code_info; public_dependency; weak_dependency; syntax })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: repeated (3, string, not_packed) ^:: repeated (4, (message (fun t -> DescriptorProto.to_proto' t)), not_packed) ^:: repeated (5, (message (fun t -> EnumDescriptorProto.to_proto' t)), not_packed) ^:: repeated (6, (message (fun t -> ServiceDescriptorProto.to_proto' t)), not_packed) ^:: repeated (7, (message (fun t -> FieldDescriptorProto.to_proto' t)), not_packed) ^:: basic_opt (8, (message (fun t -> FileOptions.to_proto' t))) ^:: basic_opt (9, (message (fun t -> SourceCodeInfo.to_proto' t))) ^:: repeated (10, int32_int, not_packed) ^:: repeated (11, int32_int, not_packed) ^:: basic_opt (12, string) ^:: nil ) in
+        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: repeated (3, string, not_packed) ^:: repeated (4, (message DescriptorProto.to_proto'), not_packed) ^:: repeated (5, (message EnumDescriptorProto.to_proto'), not_packed) ^:: repeated (6, (message ServiceDescriptorProto.to_proto'), not_packed) ^:: repeated (7, (message FieldDescriptorProto.to_proto'), not_packed) ^:: basic_opt (8, (message FileOptions.to_proto')) ^:: basic_opt (9, (message SourceCodeInfo.to_proto')) ^:: repeated (10, int32_int, not_packed) ^:: repeated (11, int32_int, not_packed) ^:: basic_opt (12, string) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { name; package; dependency; message_type; enum_type; service; extension; options; source_code_info; public_dependency; weak_dependency; syntax } -> serialize writer name package dependency message_type enum_type service extension options source_code_info public_dependency weak_dependency syntax
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun name package dependency message_type enum_type service extension options source_code_info public_dependency weak_dependency syntax -> { name; package; dependency; message_type; enum_type; service; extension; options; source_code_info; public_dependency; weak_dependency; syntax } in
-        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: repeated (3, string, not_packed) ^:: repeated (4, (message (fun t -> DescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (5, (message (fun t -> EnumDescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (6, (message (fun t -> ServiceDescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (7, (message (fun t -> FieldDescriptorProto.from_proto_exn t)), not_packed) ^:: basic_opt (8, (message (fun t -> FileOptions.from_proto_exn t))) ^:: basic_opt (9, (message (fun t -> SourceCodeInfo.from_proto_exn t))) ^:: repeated (10, int32_int, not_packed) ^:: repeated (11, int32_int, not_packed) ^:: basic_opt (12, string) ^:: nil ) in
+        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: repeated (3, string, not_packed) ^:: repeated (4, (message ((fun writer -> DescriptorProto.from_proto_exn writer), DescriptorProto.merge)), not_packed) ^:: repeated (5, (message ((fun writer -> EnumDescriptorProto.from_proto_exn writer), EnumDescriptorProto.merge)), not_packed) ^:: repeated (6, (message ((fun writer -> ServiceDescriptorProto.from_proto_exn writer), ServiceDescriptorProto.merge)), not_packed) ^:: repeated (7, (message ((fun writer -> FieldDescriptorProto.from_proto_exn writer), FieldDescriptorProto.merge)), not_packed) ^:: basic_opt (8, (message ((fun writer -> FileOptions.from_proto_exn writer), FileOptions.merge))) ^:: basic_opt (9, (message ((fun writer -> SourceCodeInfo.from_proto_exn writer), SourceCodeInfo.merge))) ^:: repeated (10, int32_int, not_packed) ^:: repeated (11, int32_int, not_packed) ^:: basic_opt (12, string) ^:: nil ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -635,6 +721,7 @@ end = struct
         val name': unit -> string
         type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
         val make: ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -644,6 +731,7 @@ end = struct
         val name': unit -> string
         type t = { start: int option; end': int option }
         val make: ?start:int -> ?end':int -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -652,6 +740,7 @@ end = struct
       val name': unit -> string
       type t = { name: string option; field: FieldDescriptorProto.t list; nested_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; extension_range: ExtensionRange.t list; extension: FieldDescriptorProto.t list; options: MessageOptions.t option; oneof_decl: OneofDescriptorProto.t list; reserved_range: ReservedRange.t list; reserved_name: string list }
       val make: ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -661,6 +750,7 @@ end = struct
         val name': unit -> string
         type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
         val make: ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -669,15 +759,23 @@ end = struct
         let name' () = "descriptor.google.protobuf.DescriptorProto.ExtensionRange"
         type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
         let make ?start ?end' ?options () = { start; end'; options }
+        let merge = (fun t1 t2 ->
+          let start = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, int32_int) ) t1.start t2.start in
+
+          let end' = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, int32_int) ) t1.end' t2.end' in
+
+          let options = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, (message ((fun writer -> ExtensionRangeOptions.from_proto_exn writer), ExtensionRangeOptions.merge))) ) t1.options t2.options in
+
+          { start; end'; options })
         let to_proto' =
-          let spec = Runtime'.Serialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, (message (fun t -> ExtensionRangeOptions.to_proto' t))) ^:: nil ) in
+          let spec = Runtime'.Serialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, (message ExtensionRangeOptions.to_proto')) ^:: nil ) in
           let serialize = Runtime'.Serialize.serialize spec in
           fun writer { start; end'; options } -> serialize writer start end' options
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
         let from_proto_exn =
           let constructor = fun start end' options -> { start; end'; options } in
-          let spec = Runtime'.Deserialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, (message (fun t -> ExtensionRangeOptions.from_proto_exn t))) ^:: nil ) in
+          let spec = Runtime'.Deserialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, (message ((fun writer -> ExtensionRangeOptions.from_proto_exn writer), ExtensionRangeOptions.merge))) ^:: nil ) in
           Runtime'.Deserialize.deserialize spec constructor
         let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
@@ -685,6 +783,7 @@ end = struct
         val name': unit -> string
         type t = { start: int option; end': int option }
         val make: ?start:int -> ?end':int -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -693,6 +792,12 @@ end = struct
         let name' () = "descriptor.google.protobuf.DescriptorProto.ReservedRange"
         type t = { start: int option; end': int option }
         let make ?start ?end' () = { start; end' }
+        let merge = (fun t1 t2 ->
+          let start = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, int32_int) ) t1.start t2.start in
+
+          let end' = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, int32_int) ) t1.end' t2.end' in
+
+          { start; end' })
         let to_proto' =
           let spec = Runtime'.Serialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: nil ) in
           let serialize = Runtime'.Serialize.serialize spec in
@@ -708,15 +813,37 @@ end = struct
       let name' () = "descriptor.google.protobuf.DescriptorProto"
       type t = { name: string option; field: FieldDescriptorProto.t list; nested_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; extension_range: ExtensionRange.t list; extension: FieldDescriptorProto.t list; options: MessageOptions.t option; oneof_decl: OneofDescriptorProto.t list; reserved_range: ReservedRange.t list; reserved_name: string list }
       let make ?name ?(field = []) ?(nested_type = []) ?(enum_type = []) ?(extension_range = []) ?(extension = []) ?options ?(oneof_decl = []) ?(reserved_range = []) ?(reserved_name = []) () = { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name }
+      let merge = (fun t1 t2 ->
+        let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name in
+
+        let field = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (2, (message ((fun writer -> FieldDescriptorProto.from_proto_exn writer), FieldDescriptorProto.merge)), not_packed) ) t1.field t2.field in
+
+        let nested_type = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (3, (message ((fun writer -> DescriptorProto.from_proto_exn writer), DescriptorProto.merge)), not_packed) ) t1.nested_type t2.nested_type in
+
+        let enum_type = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (4, (message ((fun writer -> EnumDescriptorProto.from_proto_exn writer), EnumDescriptorProto.merge)), not_packed) ) t1.enum_type t2.enum_type in
+
+        let extension_range = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (5, (message ((fun writer -> ExtensionRange.from_proto_exn writer), ExtensionRange.merge)), not_packed) ) t1.extension_range t2.extension_range in
+
+        let extension = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (6, (message ((fun writer -> FieldDescriptorProto.from_proto_exn writer), FieldDescriptorProto.merge)), not_packed) ) t1.extension t2.extension in
+
+        let options = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (7, (message ((fun writer -> MessageOptions.from_proto_exn writer), MessageOptions.merge))) ) t1.options t2.options in
+
+        let oneof_decl = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (8, (message ((fun writer -> OneofDescriptorProto.from_proto_exn writer), OneofDescriptorProto.merge)), not_packed) ) t1.oneof_decl t2.oneof_decl in
+
+        let reserved_range = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (9, (message ((fun writer -> ReservedRange.from_proto_exn writer), ReservedRange.merge)), not_packed) ) t1.reserved_range t2.reserved_range in
+
+        let reserved_name = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (10, string, not_packed) ) t1.reserved_name t2.reserved_name in
+
+        { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: repeated (2, (message (fun t -> FieldDescriptorProto.to_proto' t)), not_packed) ^:: repeated (3, (message (fun t -> DescriptorProto.to_proto' t)), not_packed) ^:: repeated (4, (message (fun t -> EnumDescriptorProto.to_proto' t)), not_packed) ^:: repeated (5, (message (fun t -> ExtensionRange.to_proto' t)), not_packed) ^:: repeated (6, (message (fun t -> FieldDescriptorProto.to_proto' t)), not_packed) ^:: basic_opt (7, (message (fun t -> MessageOptions.to_proto' t))) ^:: repeated (8, (message (fun t -> OneofDescriptorProto.to_proto' t)), not_packed) ^:: repeated (9, (message (fun t -> ReservedRange.to_proto' t)), not_packed) ^:: repeated (10, string, not_packed) ^:: nil ) in
+        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: repeated (2, (message FieldDescriptorProto.to_proto'), not_packed) ^:: repeated (3, (message DescriptorProto.to_proto'), not_packed) ^:: repeated (4, (message EnumDescriptorProto.to_proto'), not_packed) ^:: repeated (5, (message ExtensionRange.to_proto'), not_packed) ^:: repeated (6, (message FieldDescriptorProto.to_proto'), not_packed) ^:: basic_opt (7, (message MessageOptions.to_proto')) ^:: repeated (8, (message OneofDescriptorProto.to_proto'), not_packed) ^:: repeated (9, (message ReservedRange.to_proto'), not_packed) ^:: repeated (10, string, not_packed) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name } -> serialize writer name field nested_type enum_type extension_range extension options oneof_decl reserved_range reserved_name
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun name field nested_type enum_type extension_range extension options oneof_decl reserved_range reserved_name -> { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name } in
-        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: repeated (2, (message (fun t -> FieldDescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (3, (message (fun t -> DescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (4, (message (fun t -> EnumDescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (5, (message (fun t -> ExtensionRange.from_proto_exn t)), not_packed) ^:: repeated (6, (message (fun t -> FieldDescriptorProto.from_proto_exn t)), not_packed) ^:: basic_opt (7, (message (fun t -> MessageOptions.from_proto_exn t))) ^:: repeated (8, (message (fun t -> OneofDescriptorProto.from_proto_exn t)), not_packed) ^:: repeated (9, (message (fun t -> ReservedRange.from_proto_exn t)), not_packed) ^:: repeated (10, string, not_packed) ^:: nil ) in
+        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: repeated (2, (message ((fun writer -> FieldDescriptorProto.from_proto_exn writer), FieldDescriptorProto.merge)), not_packed) ^:: repeated (3, (message ((fun writer -> DescriptorProto.from_proto_exn writer), DescriptorProto.merge)), not_packed) ^:: repeated (4, (message ((fun writer -> EnumDescriptorProto.from_proto_exn writer), EnumDescriptorProto.merge)), not_packed) ^:: repeated (5, (message ((fun writer -> ExtensionRange.from_proto_exn writer), ExtensionRange.merge)), not_packed) ^:: repeated (6, (message ((fun writer -> FieldDescriptorProto.from_proto_exn writer), FieldDescriptorProto.merge)), not_packed) ^:: basic_opt (7, (message ((fun writer -> MessageOptions.from_proto_exn writer), MessageOptions.merge))) ^:: repeated (8, (message ((fun writer -> OneofDescriptorProto.from_proto_exn writer), OneofDescriptorProto.merge)), not_packed) ^:: repeated (9, (message ((fun writer -> ReservedRange.from_proto_exn writer), ReservedRange.merge)), not_packed) ^:: repeated (10, string, not_packed) ^:: nil ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -724,6 +851,7 @@ end = struct
       val name': unit -> string
       type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -732,15 +860,20 @@ end = struct
       let name' () = "descriptor.google.protobuf.ExtensionRangeOptions"
       type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { uninterpreted_option; extensions' }
+      let merge = (fun t1 t2 ->
+        let uninterpreted_option = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option in
+
+        let extensions' = List.append t1.extensions' t2.extensions' in
+        { uninterpreted_option; extensions' })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Serialize.C.( repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { uninterpreted_option; extensions' } -> serialize writer uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun uninterpreted_option extensions' -> { uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -760,6 +893,7 @@ end = struct
       val name': unit -> string
       type t = { name: string option; extendee: string option; number: int option; label: Label.t option; type': Type.t option; type_name: string option; default_value: string option; options: FieldOptions.t option; oneof_index: int option; json_name: string option; proto3_optional: bool option }
       val make: ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -838,15 +972,39 @@ end = struct
       let name' () = "descriptor.google.protobuf.FieldDescriptorProto"
       type t = { name: string option; extendee: string option; number: int option; label: Label.t option; type': Type.t option; type_name: string option; default_value: string option; options: FieldOptions.t option; oneof_index: int option; json_name: string option; proto3_optional: bool option }
       let make ?name ?extendee ?number ?label ?type' ?type_name ?default_value ?options ?oneof_index ?json_name ?proto3_optional () = { name; extendee; number; label; type'; type_name; default_value; options; oneof_index; json_name; proto3_optional }
+      let merge = (fun t1 t2 ->
+        let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name in
+
+        let extendee = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, string) ) t1.extendee t2.extendee in
+
+        let number = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, int32_int) ) t1.number t2.number in
+
+        let label = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (4, (enum Label.from_int_exn)) ) t1.label t2.label in
+
+        let type' = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (5, (enum Type.from_int_exn)) ) t1.type' t2.type' in
+
+        let type_name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (6, string) ) t1.type_name t2.type_name in
+
+        let default_value = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (7, string) ) t1.default_value t2.default_value in
+
+        let options = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (8, (message ((fun writer -> FieldOptions.from_proto_exn writer), FieldOptions.merge))) ) t1.options t2.options in
+
+        let oneof_index = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (9, int32_int) ) t1.oneof_index t2.oneof_index in
+
+        let json_name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (10, string) ) t1.json_name t2.json_name in
+
+        let proto3_optional = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (17, bool) ) t1.proto3_optional t2.proto3_optional in
+
+        { name; extendee; number; label; type'; type_name; default_value; options; oneof_index; json_name; proto3_optional })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, (enum Label.to_int)) ^:: basic_opt (5, (enum Type.to_int)) ^:: basic_opt (6, string) ^:: basic_opt (7, string) ^:: basic_opt (8, (message (fun t -> FieldOptions.to_proto' t))) ^:: basic_opt (9, int32_int) ^:: basic_opt (10, string) ^:: basic_opt (17, bool) ^:: nil ) in
+        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, (enum Label.to_int)) ^:: basic_opt (5, (enum Type.to_int)) ^:: basic_opt (6, string) ^:: basic_opt (7, string) ^:: basic_opt (8, (message FieldOptions.to_proto')) ^:: basic_opt (9, int32_int) ^:: basic_opt (10, string) ^:: basic_opt (17, bool) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { name; extendee; number; label; type'; type_name; default_value; options; oneof_index; json_name; proto3_optional } -> serialize writer name extendee number label type' type_name default_value options oneof_index json_name proto3_optional
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun name extendee number label type' type_name default_value options oneof_index json_name proto3_optional -> { name; extendee; number; label; type'; type_name; default_value; options; oneof_index; json_name; proto3_optional } in
-        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, (enum Label.from_int_exn)) ^:: basic_opt (5, (enum Type.from_int_exn)) ^:: basic_opt (6, string) ^:: basic_opt (7, string) ^:: basic_opt (8, (message (fun t -> FieldOptions.from_proto_exn t))) ^:: basic_opt (9, int32_int) ^:: basic_opt (10, string) ^:: basic_opt (17, bool) ^:: nil ) in
+        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, (enum Label.from_int_exn)) ^:: basic_opt (5, (enum Type.from_int_exn)) ^:: basic_opt (6, string) ^:: basic_opt (7, string) ^:: basic_opt (8, (message ((fun writer -> FieldOptions.from_proto_exn writer), FieldOptions.merge))) ^:: basic_opt (9, int32_int) ^:: basic_opt (10, string) ^:: basic_opt (17, bool) ^:: nil ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -854,6 +1012,7 @@ end = struct
       val name': unit -> string
       type t = { name: string option; options: OneofOptions.t option }
       val make: ?name:string -> ?options:OneofOptions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -862,15 +1021,21 @@ end = struct
       let name' () = "descriptor.google.protobuf.OneofDescriptorProto"
       type t = { name: string option; options: OneofOptions.t option }
       let make ?name ?options () = { name; options }
+      let merge = (fun t1 t2 ->
+        let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name in
+
+        let options = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, (message ((fun writer -> OneofOptions.from_proto_exn writer), OneofOptions.merge))) ) t1.options t2.options in
+
+        { name; options })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, (message (fun t -> OneofOptions.to_proto' t))) ^:: nil ) in
+        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, (message OneofOptions.to_proto')) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { name; options } -> serialize writer name options
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun name options -> { name; options } in
-        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, (message (fun t -> OneofOptions.from_proto_exn t))) ^:: nil ) in
+        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, (message ((fun writer -> OneofOptions.from_proto_exn writer), OneofOptions.merge))) ^:: nil ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -879,6 +1044,7 @@ end = struct
         val name': unit -> string
         type t = { start: int option; end': int option }
         val make: ?start:int -> ?end':int -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -887,6 +1053,7 @@ end = struct
       val name': unit -> string
       type t = { name: string option; value: EnumValueDescriptorProto.t list; options: EnumOptions.t option; reserved_range: EnumReservedRange.t list; reserved_name: string list }
       val make: ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -896,6 +1063,7 @@ end = struct
         val name': unit -> string
         type t = { start: int option; end': int option }
         val make: ?start:int -> ?end':int -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -904,6 +1072,12 @@ end = struct
         let name' () = "descriptor.google.protobuf.EnumDescriptorProto.EnumReservedRange"
         type t = { start: int option; end': int option }
         let make ?start ?end' () = { start; end' }
+        let merge = (fun t1 t2 ->
+          let start = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, int32_int) ) t1.start t2.start in
+
+          let end' = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, int32_int) ) t1.end' t2.end' in
+
+          { start; end' })
         let to_proto' =
           let spec = Runtime'.Serialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: nil ) in
           let serialize = Runtime'.Serialize.serialize spec in
@@ -919,15 +1093,27 @@ end = struct
       let name' () = "descriptor.google.protobuf.EnumDescriptorProto"
       type t = { name: string option; value: EnumValueDescriptorProto.t list; options: EnumOptions.t option; reserved_range: EnumReservedRange.t list; reserved_name: string list }
       let make ?name ?(value = []) ?options ?(reserved_range = []) ?(reserved_name = []) () = { name; value; options; reserved_range; reserved_name }
+      let merge = (fun t1 t2 ->
+        let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name in
+
+        let value = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (2, (message ((fun writer -> EnumValueDescriptorProto.from_proto_exn writer), EnumValueDescriptorProto.merge)), not_packed) ) t1.value t2.value in
+
+        let options = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, (message ((fun writer -> EnumOptions.from_proto_exn writer), EnumOptions.merge))) ) t1.options t2.options in
+
+        let reserved_range = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (4, (message ((fun writer -> EnumReservedRange.from_proto_exn writer), EnumReservedRange.merge)), not_packed) ) t1.reserved_range t2.reserved_range in
+
+        let reserved_name = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (5, string, not_packed) ) t1.reserved_name t2.reserved_name in
+
+        { name; value; options; reserved_range; reserved_name })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: repeated (2, (message (fun t -> EnumValueDescriptorProto.to_proto' t)), not_packed) ^:: basic_opt (3, (message (fun t -> EnumOptions.to_proto' t))) ^:: repeated (4, (message (fun t -> EnumReservedRange.to_proto' t)), not_packed) ^:: repeated (5, string, not_packed) ^:: nil ) in
+        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: repeated (2, (message EnumValueDescriptorProto.to_proto'), not_packed) ^:: basic_opt (3, (message EnumOptions.to_proto')) ^:: repeated (4, (message EnumReservedRange.to_proto'), not_packed) ^:: repeated (5, string, not_packed) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { name; value; options; reserved_range; reserved_name } -> serialize writer name value options reserved_range reserved_name
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun name value options reserved_range reserved_name -> { name; value; options; reserved_range; reserved_name } in
-        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: repeated (2, (message (fun t -> EnumValueDescriptorProto.from_proto_exn t)), not_packed) ^:: basic_opt (3, (message (fun t -> EnumOptions.from_proto_exn t))) ^:: repeated (4, (message (fun t -> EnumReservedRange.from_proto_exn t)), not_packed) ^:: repeated (5, string, not_packed) ^:: nil ) in
+        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: repeated (2, (message ((fun writer -> EnumValueDescriptorProto.from_proto_exn writer), EnumValueDescriptorProto.merge)), not_packed) ^:: basic_opt (3, (message ((fun writer -> EnumOptions.from_proto_exn writer), EnumOptions.merge))) ^:: repeated (4, (message ((fun writer -> EnumReservedRange.from_proto_exn writer), EnumReservedRange.merge)), not_packed) ^:: repeated (5, string, not_packed) ^:: nil ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -935,6 +1121,7 @@ end = struct
       val name': unit -> string
       type t = { name: string option; number: int option; options: EnumValueOptions.t option }
       val make: ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -943,15 +1130,23 @@ end = struct
       let name' () = "descriptor.google.protobuf.EnumValueDescriptorProto"
       type t = { name: string option; number: int option; options: EnumValueOptions.t option }
       let make ?name ?number ?options () = { name; number; options }
+      let merge = (fun t1 t2 ->
+        let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name in
+
+        let number = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, int32_int) ) t1.number t2.number in
+
+        let options = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, (message ((fun writer -> EnumValueOptions.from_proto_exn writer), EnumValueOptions.merge))) ) t1.options t2.options in
+
+        { name; number; options })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, (message (fun t -> EnumValueOptions.to_proto' t))) ^:: nil ) in
+        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, (message EnumValueOptions.to_proto')) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { name; number; options } -> serialize writer name number options
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun name number options -> { name; number; options } in
-        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, (message (fun t -> EnumValueOptions.from_proto_exn t))) ^:: nil ) in
+        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, (message ((fun writer -> EnumValueOptions.from_proto_exn writer), EnumValueOptions.merge))) ^:: nil ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -959,6 +1154,7 @@ end = struct
       val name': unit -> string
       type t = { name: string option; method': MethodDescriptorProto.t list; options: ServiceOptions.t option }
       val make: ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -967,15 +1163,23 @@ end = struct
       let name' () = "descriptor.google.protobuf.ServiceDescriptorProto"
       type t = { name: string option; method': MethodDescriptorProto.t list; options: ServiceOptions.t option }
       let make ?name ?(method' = []) ?options () = { name; method'; options }
+      let merge = (fun t1 t2 ->
+        let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name in
+
+        let method' = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (2, (message ((fun writer -> MethodDescriptorProto.from_proto_exn writer), MethodDescriptorProto.merge)), not_packed) ) t1.method' t2.method' in
+
+        let options = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, (message ((fun writer -> ServiceOptions.from_proto_exn writer), ServiceOptions.merge))) ) t1.options t2.options in
+
+        { name; method'; options })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: repeated (2, (message (fun t -> MethodDescriptorProto.to_proto' t)), not_packed) ^:: basic_opt (3, (message (fun t -> ServiceOptions.to_proto' t))) ^:: nil ) in
+        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: repeated (2, (message MethodDescriptorProto.to_proto'), not_packed) ^:: basic_opt (3, (message ServiceOptions.to_proto')) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { name; method'; options } -> serialize writer name method' options
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun name method' options -> { name; method'; options } in
-        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: repeated (2, (message (fun t -> MethodDescriptorProto.from_proto_exn t)), not_packed) ^:: basic_opt (3, (message (fun t -> ServiceOptions.from_proto_exn t))) ^:: nil ) in
+        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: repeated (2, (message ((fun writer -> MethodDescriptorProto.from_proto_exn writer), MethodDescriptorProto.merge)), not_packed) ^:: basic_opt (3, (message ((fun writer -> ServiceOptions.from_proto_exn writer), ServiceOptions.merge))) ^:: nil ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -983,6 +1187,7 @@ end = struct
       val name': unit -> string
       type t = { name: string option; input_type: string option; output_type: string option; options: MethodOptions.t option; client_streaming: bool; server_streaming: bool }
       val make: ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -991,15 +1196,29 @@ end = struct
       let name' () = "descriptor.google.protobuf.MethodDescriptorProto"
       type t = { name: string option; input_type: string option; output_type: string option; options: MethodOptions.t option; client_streaming: bool; server_streaming: bool }
       let make ?name ?input_type ?output_type ?options ?(client_streaming = false) ?(server_streaming = false) () = { name; input_type; output_type; options; client_streaming; server_streaming }
+      let merge = (fun t1 t2 ->
+        let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name in
+
+        let input_type = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, string) ) t1.input_type t2.input_type in
+
+        let output_type = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, string) ) t1.output_type t2.output_type in
+
+        let options = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (4, (message ((fun writer -> MethodOptions.from_proto_exn writer), MethodOptions.merge))) ) t1.options t2.options in
+
+        let client_streaming = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (5, bool, Some (false)) ) t1.client_streaming t2.client_streaming in
+
+        let server_streaming = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (6, bool, Some (false)) ) t1.server_streaming t2.server_streaming in
+
+        { name; input_type; output_type; options; client_streaming; server_streaming })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, string) ^:: basic_opt (4, (message (fun t -> MethodOptions.to_proto' t))) ^:: basic (5, bool, Some (false)) ^:: basic (6, bool, Some (false)) ^:: nil ) in
+        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, string) ^:: basic_opt (4, (message MethodOptions.to_proto')) ^:: basic (5, bool, Some (false)) ^:: basic (6, bool, Some (false)) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { name; input_type; output_type; options; client_streaming; server_streaming } -> serialize writer name input_type output_type options client_streaming server_streaming
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun name input_type output_type options client_streaming server_streaming -> { name; input_type; output_type; options; client_streaming; server_streaming } in
-        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, string) ^:: basic_opt (4, (message (fun t -> MethodOptions.from_proto_exn t))) ^:: basic (5, bool, Some (false)) ^:: basic (6, bool, Some (false)) ^:: nil ) in
+        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, string) ^:: basic_opt (4, (message ((fun writer -> MethodOptions.from_proto_exn writer), MethodOptions.merge))) ^:: basic (5, bool, Some (false)) ^:: basic (6, bool, Some (false)) ^:: nil ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1013,6 +1232,7 @@ end = struct
       val name': unit -> string
       type t = { java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1041,15 +1261,60 @@ end = struct
       let name' () = "descriptor.google.protobuf.FileOptions"
       type t = { java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?java_package ?java_outer_classname ?(optimize_for = OptimizeMode.SPEED) ?(java_multiple_files = false) ?go_package ?(cc_generic_services = false) ?(java_generic_services = false) ?(py_generic_services = false) ?java_generate_equals_and_hash ?(deprecated = false) ?(java_string_check_utf8 = false) ?(cc_enable_arenas = true) ?objc_class_prefix ?csharp_namespace ?swift_prefix ?php_class_prefix ?php_namespace ?(php_generic_services = false) ?php_metadata_namespace ?ruby_package ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { java_package; java_outer_classname; optimize_for; java_multiple_files; go_package; cc_generic_services; java_generic_services; py_generic_services; java_generate_equals_and_hash; deprecated; java_string_check_utf8; cc_enable_arenas; objc_class_prefix; csharp_namespace; swift_prefix; php_class_prefix; php_namespace; php_generic_services; php_metadata_namespace; ruby_package; uninterpreted_option; extensions' }
+      let merge = (fun t1 t2 ->
+        let java_package = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.java_package t2.java_package in
+
+        let java_outer_classname = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (8, string) ) t1.java_outer_classname t2.java_outer_classname in
+
+        let optimize_for = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (9, (enum OptimizeMode.from_int_exn), Some (OptimizeMode.SPEED)) ) t1.optimize_for t2.optimize_for in
+
+        let java_multiple_files = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (10, bool, Some (false)) ) t1.java_multiple_files t2.java_multiple_files in
+
+        let go_package = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (11, string) ) t1.go_package t2.go_package in
+
+        let cc_generic_services = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (16, bool, Some (false)) ) t1.cc_generic_services t2.cc_generic_services in
+
+        let java_generic_services = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (17, bool, Some (false)) ) t1.java_generic_services t2.java_generic_services in
+
+        let py_generic_services = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (18, bool, Some (false)) ) t1.py_generic_services t2.py_generic_services in
+
+        let java_generate_equals_and_hash = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (20, bool) ) t1.java_generate_equals_and_hash t2.java_generate_equals_and_hash in
+
+        let deprecated = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (23, bool, Some (false)) ) t1.deprecated t2.deprecated in
+
+        let java_string_check_utf8 = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (27, bool, Some (false)) ) t1.java_string_check_utf8 t2.java_string_check_utf8 in
+
+        let cc_enable_arenas = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (31, bool, Some (true)) ) t1.cc_enable_arenas t2.cc_enable_arenas in
+
+        let objc_class_prefix = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (36, string) ) t1.objc_class_prefix t2.objc_class_prefix in
+
+        let csharp_namespace = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (37, string) ) t1.csharp_namespace t2.csharp_namespace in
+
+        let swift_prefix = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (39, string) ) t1.swift_prefix t2.swift_prefix in
+
+        let php_class_prefix = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (40, string) ) t1.php_class_prefix t2.php_class_prefix in
+
+        let php_namespace = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (41, string) ) t1.php_namespace t2.php_namespace in
+
+        let php_generic_services = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (42, bool, Some (false)) ) t1.php_generic_services t2.php_generic_services in
+
+        let php_metadata_namespace = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (44, string) ) t1.php_metadata_namespace t2.php_metadata_namespace in
+
+        let ruby_package = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (45, string) ) t1.ruby_package t2.ruby_package in
+
+        let uninterpreted_option = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option in
+
+        let extensions' = List.append t1.extensions' t2.extensions' in
+        { java_package; java_outer_classname; optimize_for; java_multiple_files; go_package; cc_generic_services; java_generic_services; py_generic_services; java_generate_equals_and_hash; deprecated; java_string_check_utf8; cc_enable_arenas; objc_class_prefix; csharp_namespace; swift_prefix; php_class_prefix; php_namespace; php_generic_services; php_metadata_namespace; ruby_package; uninterpreted_option; extensions' })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (8, string) ^:: basic (9, (enum OptimizeMode.to_int), Some (OptimizeMode.SPEED)) ^:: basic (10, bool, Some (false)) ^:: basic_opt (11, string) ^:: basic (16, bool, Some (false)) ^:: basic (17, bool, Some (false)) ^:: basic (18, bool, Some (false)) ^:: basic_opt (20, bool) ^:: basic (23, bool, Some (false)) ^:: basic (27, bool, Some (false)) ^:: basic (31, bool, Some (true)) ^:: basic_opt (36, string) ^:: basic_opt (37, string) ^:: basic_opt (39, string) ^:: basic_opt (40, string) ^:: basic_opt (41, string) ^:: basic (42, bool, Some (false)) ^:: basic_opt (44, string) ^:: basic_opt (45, string) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (8, string) ^:: basic (9, (enum OptimizeMode.to_int), Some (OptimizeMode.SPEED)) ^:: basic (10, bool, Some (false)) ^:: basic_opt (11, string) ^:: basic (16, bool, Some (false)) ^:: basic (17, bool, Some (false)) ^:: basic (18, bool, Some (false)) ^:: basic_opt (20, bool) ^:: basic (23, bool, Some (false)) ^:: basic (27, bool, Some (false)) ^:: basic (31, bool, Some (true)) ^:: basic_opt (36, string) ^:: basic_opt (37, string) ^:: basic_opt (39, string) ^:: basic_opt (40, string) ^:: basic_opt (41, string) ^:: basic (42, bool, Some (false)) ^:: basic_opt (44, string) ^:: basic_opt (45, string) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { java_package; java_outer_classname; optimize_for; java_multiple_files; go_package; cc_generic_services; java_generic_services; py_generic_services; java_generate_equals_and_hash; deprecated; java_string_check_utf8; cc_enable_arenas; objc_class_prefix; csharp_namespace; swift_prefix; php_class_prefix; php_namespace; php_generic_services; php_metadata_namespace; ruby_package; uninterpreted_option; extensions' } -> serialize writer java_package java_outer_classname optimize_for java_multiple_files go_package cc_generic_services java_generic_services py_generic_services java_generate_equals_and_hash deprecated java_string_check_utf8 cc_enable_arenas objc_class_prefix csharp_namespace swift_prefix php_class_prefix php_namespace php_generic_services php_metadata_namespace ruby_package uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun java_package java_outer_classname optimize_for java_multiple_files go_package cc_generic_services java_generic_services py_generic_services java_generate_equals_and_hash deprecated java_string_check_utf8 cc_enable_arenas objc_class_prefix csharp_namespace swift_prefix php_class_prefix php_namespace php_generic_services php_metadata_namespace ruby_package uninterpreted_option extensions' -> { java_package; java_outer_classname; optimize_for; java_multiple_files; go_package; cc_generic_services; java_generic_services; py_generic_services; java_generate_equals_and_hash; deprecated; java_string_check_utf8; cc_enable_arenas; objc_class_prefix; csharp_namespace; swift_prefix; php_class_prefix; php_namespace; php_generic_services; php_metadata_namespace; ruby_package; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (8, string) ^:: basic (9, (enum OptimizeMode.from_int_exn), Some (OptimizeMode.SPEED)) ^:: basic (10, bool, Some (false)) ^:: basic_opt (11, string) ^:: basic (16, bool, Some (false)) ^:: basic (17, bool, Some (false)) ^:: basic (18, bool, Some (false)) ^:: basic_opt (20, bool) ^:: basic (23, bool, Some (false)) ^:: basic (27, bool, Some (false)) ^:: basic (31, bool, Some (true)) ^:: basic_opt (36, string) ^:: basic_opt (37, string) ^:: basic_opt (39, string) ^:: basic_opt (40, string) ^:: basic_opt (41, string) ^:: basic (42, bool, Some (false)) ^:: basic_opt (44, string) ^:: basic_opt (45, string) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (8, string) ^:: basic (9, (enum OptimizeMode.from_int_exn), Some (OptimizeMode.SPEED)) ^:: basic (10, bool, Some (false)) ^:: basic_opt (11, string) ^:: basic (16, bool, Some (false)) ^:: basic (17, bool, Some (false)) ^:: basic (18, bool, Some (false)) ^:: basic_opt (20, bool) ^:: basic (23, bool, Some (false)) ^:: basic (27, bool, Some (false)) ^:: basic (31, bool, Some (true)) ^:: basic_opt (36, string) ^:: basic_opt (37, string) ^:: basic_opt (39, string) ^:: basic_opt (40, string) ^:: basic_opt (41, string) ^:: basic (42, bool, Some (false)) ^:: basic_opt (44, string) ^:: basic_opt (45, string) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1057,6 +1322,7 @@ end = struct
       val name': unit -> string
       type t = { message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1065,15 +1331,28 @@ end = struct
       let name' () = "descriptor.google.protobuf.MessageOptions"
       type t = { message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(message_set_wire_format = false) ?(no_standard_descriptor_accessor = false) ?(deprecated = false) ?map_entry ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { message_set_wire_format; no_standard_descriptor_accessor; deprecated; map_entry; uninterpreted_option; extensions' }
+      let merge = (fun t1 t2 ->
+        let message_set_wire_format = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ) t1.message_set_wire_format t2.message_set_wire_format in
+
+        let no_standard_descriptor_accessor = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (2, bool, Some (false)) ) t1.no_standard_descriptor_accessor t2.no_standard_descriptor_accessor in
+
+        let deprecated = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (3, bool, Some (false)) ) t1.deprecated t2.deprecated in
+
+        let map_entry = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (7, bool) ) t1.map_entry t2.map_entry in
+
+        let uninterpreted_option = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option in
+
+        let extensions' = List.append t1.extensions' t2.extensions' in
+        { message_set_wire_format; no_standard_descriptor_accessor; deprecated; map_entry; uninterpreted_option; extensions' })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic (1, bool, Some (false)) ^:: basic (2, bool, Some (false)) ^:: basic (3, bool, Some (false)) ^:: basic_opt (7, bool) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Serialize.C.( basic (1, bool, Some (false)) ^:: basic (2, bool, Some (false)) ^:: basic (3, bool, Some (false)) ^:: basic_opt (7, bool) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { message_set_wire_format; no_standard_descriptor_accessor; deprecated; map_entry; uninterpreted_option; extensions' } -> serialize writer message_set_wire_format no_standard_descriptor_accessor deprecated map_entry uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun message_set_wire_format no_standard_descriptor_accessor deprecated map_entry uninterpreted_option extensions' -> { message_set_wire_format; no_standard_descriptor_accessor; deprecated; map_entry; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ^:: basic (2, bool, Some (false)) ^:: basic (3, bool, Some (false)) ^:: basic_opt (7, bool) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ^:: basic (2, bool, Some (false)) ^:: basic (3, bool, Some (false)) ^:: basic_opt (7, bool) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1093,6 +1372,7 @@ end = struct
       val name': unit -> string
       type t = { ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1141,15 +1421,34 @@ end = struct
       let name' () = "descriptor.google.protobuf.FieldOptions"
       type t = { ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(ctype = CType.STRING) ?packed ?(deprecated = false) ?(lazy' = false) ?(jstype = JSType.JS_NORMAL) ?(weak = false) ?(unverified_lazy = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { ctype; packed; deprecated; lazy'; jstype; weak; unverified_lazy; uninterpreted_option; extensions' }
+      let merge = (fun t1 t2 ->
+        let ctype = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (1, (enum CType.from_int_exn), Some (CType.STRING)) ) t1.ctype t2.ctype in
+
+        let packed = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, bool) ) t1.packed t2.packed in
+
+        let deprecated = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (3, bool, Some (false)) ) t1.deprecated t2.deprecated in
+
+        let lazy' = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (5, bool, Some (false)) ) t1.lazy' t2.lazy' in
+
+        let jstype = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (6, (enum JSType.from_int_exn), Some (JSType.JS_NORMAL)) ) t1.jstype t2.jstype in
+
+        let weak = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (10, bool, Some (false)) ) t1.weak t2.weak in
+
+        let unverified_lazy = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (15, bool, Some (false)) ) t1.unverified_lazy t2.unverified_lazy in
+
+        let uninterpreted_option = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option in
+
+        let extensions' = List.append t1.extensions' t2.extensions' in
+        { ctype; packed; deprecated; lazy'; jstype; weak; unverified_lazy; uninterpreted_option; extensions' })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic (1, (enum CType.to_int), Some (CType.STRING)) ^:: basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: basic (5, bool, Some (false)) ^:: basic (6, (enum JSType.to_int), Some (JSType.JS_NORMAL)) ^:: basic (10, bool, Some (false)) ^:: basic (15, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Serialize.C.( basic (1, (enum CType.to_int), Some (CType.STRING)) ^:: basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: basic (5, bool, Some (false)) ^:: basic (6, (enum JSType.to_int), Some (JSType.JS_NORMAL)) ^:: basic (10, bool, Some (false)) ^:: basic (15, bool, Some (false)) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { ctype; packed; deprecated; lazy'; jstype; weak; unverified_lazy; uninterpreted_option; extensions' } -> serialize writer ctype packed deprecated lazy' jstype weak unverified_lazy uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun ctype packed deprecated lazy' jstype weak unverified_lazy uninterpreted_option extensions' -> { ctype; packed; deprecated; lazy'; jstype; weak; unverified_lazy; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (1, (enum CType.from_int_exn), Some (CType.STRING)) ^:: basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: basic (5, bool, Some (false)) ^:: basic (6, (enum JSType.from_int_exn), Some (JSType.JS_NORMAL)) ^:: basic (10, bool, Some (false)) ^:: basic (15, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Deserialize.C.( basic (1, (enum CType.from_int_exn), Some (CType.STRING)) ^:: basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: basic (5, bool, Some (false)) ^:: basic (6, (enum JSType.from_int_exn), Some (JSType.JS_NORMAL)) ^:: basic (10, bool, Some (false)) ^:: basic (15, bool, Some (false)) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1157,6 +1456,7 @@ end = struct
       val name': unit -> string
       type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1165,15 +1465,20 @@ end = struct
       let name' () = "descriptor.google.protobuf.OneofOptions"
       type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { uninterpreted_option; extensions' }
+      let merge = (fun t1 t2 ->
+        let uninterpreted_option = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option in
+
+        let extensions' = List.append t1.extensions' t2.extensions' in
+        { uninterpreted_option; extensions' })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Serialize.C.( repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { uninterpreted_option; extensions' } -> serialize writer uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun uninterpreted_option extensions' -> { uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1181,6 +1486,7 @@ end = struct
       val name': unit -> string
       type t = { allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1189,15 +1495,24 @@ end = struct
       let name' () = "descriptor.google.protobuf.EnumOptions"
       type t = { allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?allow_alias ?(deprecated = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { allow_alias; deprecated; uninterpreted_option; extensions' }
+      let merge = (fun t1 t2 ->
+        let allow_alias = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, bool) ) t1.allow_alias t2.allow_alias in
+
+        let deprecated = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (3, bool, Some (false)) ) t1.deprecated t2.deprecated in
+
+        let uninterpreted_option = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option in
+
+        let extensions' = List.append t1.extensions' t2.extensions' in
+        { allow_alias; deprecated; uninterpreted_option; extensions' })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Serialize.C.( basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { allow_alias; deprecated; uninterpreted_option; extensions' } -> serialize writer allow_alias deprecated uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun allow_alias deprecated uninterpreted_option extensions' -> { allow_alias; deprecated; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Deserialize.C.( basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1205,6 +1520,7 @@ end = struct
       val name': unit -> string
       type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1213,15 +1529,22 @@ end = struct
       let name' () = "descriptor.google.protobuf.EnumValueOptions"
       type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(deprecated = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { deprecated; uninterpreted_option; extensions' }
+      let merge = (fun t1 t2 ->
+        let deprecated = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ) t1.deprecated t2.deprecated in
+
+        let uninterpreted_option = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option in
+
+        let extensions' = List.append t1.extensions' t2.extensions' in
+        { deprecated; uninterpreted_option; extensions' })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic (1, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Serialize.C.( basic (1, bool, Some (false)) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { deprecated; uninterpreted_option; extensions' } -> serialize writer deprecated uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun deprecated uninterpreted_option extensions' -> { deprecated; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1229,6 +1552,7 @@ end = struct
       val name': unit -> string
       type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1237,15 +1561,22 @@ end = struct
       let name' () = "descriptor.google.protobuf.ServiceOptions"
       type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(deprecated = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { deprecated; uninterpreted_option; extensions' }
+      let merge = (fun t1 t2 ->
+        let deprecated = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (33, bool, Some (false)) ) t1.deprecated t2.deprecated in
+
+        let uninterpreted_option = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option in
+
+        let extensions' = List.append t1.extensions' t2.extensions' in
+        { deprecated; uninterpreted_option; extensions' })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic (33, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Serialize.C.( basic (33, bool, Some (false)) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { deprecated; uninterpreted_option; extensions' } -> serialize writer deprecated uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun deprecated uninterpreted_option extensions' -> { deprecated; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (33, bool, Some (false)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Deserialize.C.( basic (33, bool, Some (false)) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1259,6 +1590,7 @@ end = struct
       val name': unit -> string
       type t = { deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       val make: ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1287,15 +1619,24 @@ end = struct
       let name' () = "descriptor.google.protobuf.MethodOptions"
       type t = { deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(deprecated = false) ?(idempotency_level = IdempotencyLevel.IDEMPOTENCY_UNKNOWN) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { deprecated; idempotency_level; uninterpreted_option; extensions' }
+      let merge = (fun t1 t2 ->
+        let deprecated = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (33, bool, Some (false)) ) t1.deprecated t2.deprecated in
+
+        let idempotency_level = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (34, (enum IdempotencyLevel.from_int_exn), Some (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ) t1.idempotency_level t2.idempotency_level in
+
+        let uninterpreted_option = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option in
+
+        let extensions' = List.append t1.extensions' t2.extensions' in
+        { deprecated; idempotency_level; uninterpreted_option; extensions' })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic (33, bool, Some (false)) ^:: basic (34, (enum IdempotencyLevel.to_int), Some (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ^:: repeated (999, (message (fun t -> UninterpretedOption.to_proto' t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Serialize.C.( basic (33, bool, Some (false)) ^:: basic (34, (enum IdempotencyLevel.to_int), Some (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { deprecated; idempotency_level; uninterpreted_option; extensions' } -> serialize writer deprecated idempotency_level uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun deprecated idempotency_level uninterpreted_option extensions' -> { deprecated; idempotency_level; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (33, bool, Some (false)) ^:: basic (34, (enum IdempotencyLevel.from_int_exn), Some (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ^:: repeated (999, (message (fun t -> UninterpretedOption.from_proto_exn t)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Deserialize.C.( basic (33, bool, Some (false)) ^:: basic (34, (enum IdempotencyLevel.from_int_exn), Some (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1304,6 +1645,7 @@ end = struct
         val name': unit -> string
         type t = { name_part: string; is_extension: bool }
         val make: name_part:string -> is_extension:bool -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1312,6 +1654,7 @@ end = struct
       val name': unit -> string
       type t = { name: NamePart.t list; identifier_value: string option; positive_int_value: int option; negative_int_value: int option; double_value: float option; string_value: bytes option; aggregate_value: string option }
       val make: ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1321,6 +1664,7 @@ end = struct
         val name': unit -> string
         type t = { name_part: string; is_extension: bool }
         val make: name_part:string -> is_extension:bool -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1329,6 +1673,12 @@ end = struct
         let name' () = "descriptor.google.protobuf.UninterpretedOption.NamePart"
         type t = { name_part: string; is_extension: bool }
         let make ~name_part ~is_extension () = { name_part; is_extension }
+        let merge = (fun t1 t2 ->
+          let name_part = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (1, string, None) ) t1.name_part t2.name_part in
+
+          let is_extension = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (2, bool, None) ) t1.is_extension t2.is_extension in
+
+          { name_part; is_extension })
         let to_proto' =
           let spec = Runtime'.Serialize.C.( basic (1, string, None) ^:: basic (2, bool, None) ^:: nil ) in
           let serialize = Runtime'.Serialize.serialize spec in
@@ -1344,15 +1694,31 @@ end = struct
       let name' () = "descriptor.google.protobuf.UninterpretedOption"
       type t = { name: NamePart.t list; identifier_value: string option; positive_int_value: int option; negative_int_value: int option; double_value: float option; string_value: bytes option; aggregate_value: string option }
       let make ?(name = []) ?identifier_value ?positive_int_value ?negative_int_value ?double_value ?string_value ?aggregate_value () = { name; identifier_value; positive_int_value; negative_int_value; double_value; string_value; aggregate_value }
+      let merge = (fun t1 t2 ->
+        let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (2, (message ((fun writer -> NamePart.from_proto_exn writer), NamePart.merge)), not_packed) ) t1.name t2.name in
+
+        let identifier_value = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, string) ) t1.identifier_value t2.identifier_value in
+
+        let positive_int_value = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (4, uint64_int) ) t1.positive_int_value t2.positive_int_value in
+
+        let negative_int_value = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (5, int64_int) ) t1.negative_int_value t2.negative_int_value in
+
+        let double_value = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (6, double) ) t1.double_value t2.double_value in
+
+        let string_value = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (7, bytes) ) t1.string_value t2.string_value in
+
+        let aggregate_value = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (8, string) ) t1.aggregate_value t2.aggregate_value in
+
+        { name; identifier_value; positive_int_value; negative_int_value; double_value; string_value; aggregate_value })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( repeated (2, (message (fun t -> NamePart.to_proto' t)), not_packed) ^:: basic_opt (3, string) ^:: basic_opt (4, uint64_int) ^:: basic_opt (5, int64_int) ^:: basic_opt (6, double) ^:: basic_opt (7, bytes) ^:: basic_opt (8, string) ^:: nil ) in
+        let spec = Runtime'.Serialize.C.( repeated (2, (message NamePart.to_proto'), not_packed) ^:: basic_opt (3, string) ^:: basic_opt (4, uint64_int) ^:: basic_opt (5, int64_int) ^:: basic_opt (6, double) ^:: basic_opt (7, bytes) ^:: basic_opt (8, string) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { name; identifier_value; positive_int_value; negative_int_value; double_value; string_value; aggregate_value } -> serialize writer name identifier_value positive_int_value negative_int_value double_value string_value aggregate_value
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun name identifier_value positive_int_value negative_int_value double_value string_value aggregate_value -> { name; identifier_value; positive_int_value; negative_int_value; double_value; string_value; aggregate_value } in
-        let spec = Runtime'.Deserialize.C.( repeated (2, (message (fun t -> NamePart.from_proto_exn t)), not_packed) ^:: basic_opt (3, string) ^:: basic_opt (4, uint64_int) ^:: basic_opt (5, int64_int) ^:: basic_opt (6, double) ^:: basic_opt (7, bytes) ^:: basic_opt (8, string) ^:: nil ) in
+        let spec = Runtime'.Deserialize.C.( repeated (2, (message ((fun writer -> NamePart.from_proto_exn writer), NamePart.merge)), not_packed) ^:: basic_opt (3, string) ^:: basic_opt (4, uint64_int) ^:: basic_opt (5, int64_int) ^:: basic_opt (6, double) ^:: basic_opt (7, bytes) ^:: basic_opt (8, string) ^:: nil ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1361,14 +1727,16 @@ end = struct
         val name': unit -> string
         type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
         val make: ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
       end
       val name': unit -> string
-      type t = Location.t list
+      type t = (Location.t list)
       val make: ?location:Location.t list -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1378,6 +1746,7 @@ end = struct
         val name': unit -> string
         type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
         val make: ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1386,6 +1755,18 @@ end = struct
         let name' () = "descriptor.google.protobuf.SourceCodeInfo.Location"
         type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
         let make ?(path = []) ?(span = []) ?leading_comments ?trailing_comments ?(leading_detached_comments = []) () = { path; span; leading_comments; trailing_comments; leading_detached_comments }
+        let merge = (fun t1 t2 ->
+          let path = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (1, int32_int, packed) ) t1.path t2.path in
+
+          let span = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (2, int32_int, packed) ) t1.span t2.span in
+
+          let leading_comments = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, string) ) t1.leading_comments t2.leading_comments in
+
+          let trailing_comments = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (4, string) ) t1.trailing_comments t2.trailing_comments in
+
+          let leading_detached_comments = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (6, string, not_packed) ) t1.leading_detached_comments t2.leading_detached_comments in
+
+          { path; span; leading_comments; trailing_comments; leading_detached_comments })
         let to_proto' =
           let spec = Runtime'.Serialize.C.( repeated (1, int32_int, packed) ^:: repeated (2, int32_int, packed) ^:: basic_opt (3, string) ^:: basic_opt (4, string) ^:: repeated (6, string, not_packed) ^:: nil ) in
           let serialize = Runtime'.Serialize.serialize spec in
@@ -1399,17 +1780,21 @@ end = struct
         let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       let name' () = "descriptor.google.protobuf.SourceCodeInfo"
-      type t = Location.t list
-      let make ?(location = []) () = location
+      type t = (Location.t list)
+      let make ?(location = []) () = (location)
+      let merge = (fun (t1_location) (t2_location) ->
+        let location = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (1, (message ((fun writer -> Location.from_proto_exn writer), Location.merge)), not_packed) ) t1_location t2_location in
+
+        (location))
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( repeated (1, (message (fun t -> Location.to_proto' t)), not_packed) ^:: nil ) in
+        let spec = Runtime'.Serialize.C.( repeated (1, (message Location.to_proto'), not_packed) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
         serialize
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
-        let constructor = fun location -> location in
-        let spec = Runtime'.Deserialize.C.( repeated (1, (message (fun t -> Location.from_proto_exn t)), not_packed) ^:: nil ) in
+        let constructor = fun location -> (location) in
+        let spec = Runtime'.Deserialize.C.( repeated (1, (message ((fun writer -> Location.from_proto_exn writer), Location.merge)), not_packed) ^:: nil ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1418,14 +1803,16 @@ end = struct
         val name': unit -> string
         type t = { path: int list; source_file: string option; begin': int option; end': int option }
         val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
       end
       val name': unit -> string
-      type t = Annotation.t list
+      type t = (Annotation.t list)
       val make: ?annotation:Annotation.t list -> unit -> t
+      val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
       val to_proto: t -> Runtime'.Writer.t
       val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1435,6 +1822,7 @@ end = struct
         val name': unit -> string
         type t = { path: int list; source_file: string option; begin': int option; end': int option }
         val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -1443,6 +1831,16 @@ end = struct
         let name' () = "descriptor.google.protobuf.GeneratedCodeInfo.Annotation"
         type t = { path: int list; source_file: string option; begin': int option; end': int option }
         let make ?(path = []) ?source_file ?begin' ?end' () = { path; source_file; begin'; end' }
+        let merge = (fun t1 t2 ->
+          let path = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (1, int32_int, packed) ) t1.path t2.path in
+
+          let source_file = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, string) ) t1.source_file t2.source_file in
+
+          let begin' = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, int32_int) ) t1.begin' t2.begin' in
+
+          let end' = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (4, int32_int) ) t1.end' t2.end' in
+
+          { path; source_file; begin'; end' })
         let to_proto' =
           let spec = Runtime'.Serialize.C.( repeated (1, int32_int, packed) ^:: basic_opt (2, string) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, int32_int) ^:: nil ) in
           let serialize = Runtime'.Serialize.serialize spec in
@@ -1456,17 +1854,21 @@ end = struct
         let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       let name' () = "descriptor.google.protobuf.GeneratedCodeInfo"
-      type t = Annotation.t list
-      let make ?(annotation = []) () = annotation
+      type t = (Annotation.t list)
+      let make ?(annotation = []) () = (annotation)
+      let merge = (fun (t1_annotation) (t2_annotation) ->
+        let annotation = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (1, (message ((fun writer -> Annotation.from_proto_exn writer), Annotation.merge)), not_packed) ) t1_annotation t2_annotation in
+
+        (annotation))
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( repeated (1, (message (fun t -> Annotation.to_proto' t)), not_packed) ^:: nil ) in
+        let spec = Runtime'.Serialize.C.( repeated (1, (message Annotation.to_proto'), not_packed) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
         serialize
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
-        let constructor = fun annotation -> annotation in
-        let spec = Runtime'.Deserialize.C.( repeated (1, (message (fun t -> Annotation.from_proto_exn t)), not_packed) ^:: nil ) in
+        let constructor = fun annotation -> (annotation) in
+        let spec = Runtime'.Deserialize.C.( repeated (1, (message ((fun writer -> Annotation.from_proto_exn writer), Annotation.merge)), not_packed) ^:: nil ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end

--- a/src/spec/descriptor.ml
+++ b/src/spec/descriptor.ml
@@ -649,10 +649,7 @@ end = struct
       let name' () = "descriptor.google.protobuf.FileDescriptorSet"
       type t = (FileDescriptorProto.t list)
       let make ?(file = []) () = (file)
-      let merge = (fun (t1_file) (t2_file) ->
-        let file = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (1, (message ((fun writer -> FileDescriptorProto.from_proto_exn writer), FileDescriptorProto.merge)), not_packed) ) t1_file t2_file in
-
-        (file))
+      let merge = (fun (t1_file) (t2_file) -> (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (1, (message ((fun writer -> FileDescriptorProto.from_proto_exn writer), FileDescriptorProto.merge)), not_packed) ) t1_file t2_file))
       let to_proto' =
         let spec = Runtime'.Serialize.C.( repeated (1, (message FileDescriptorProto.to_proto'), not_packed) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
@@ -678,32 +675,20 @@ end = struct
       let name' () = "descriptor.google.protobuf.FileDescriptorProto"
       type t = { name: string option; package: string option; dependency: string list; message_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; service: ServiceDescriptorProto.t list; extension: FieldDescriptorProto.t list; options: FileOptions.t option; source_code_info: SourceCodeInfo.t option; public_dependency: int list; weak_dependency: int list; syntax: string option }
       let make ?name ?package ?(dependency = []) ?(message_type = []) ?(enum_type = []) ?(service = []) ?(extension = []) ?options ?source_code_info ?(public_dependency = []) ?(weak_dependency = []) ?syntax () = { name; package; dependency; message_type; enum_type; service; extension; options; source_code_info; public_dependency; weak_dependency; syntax }
-      let merge = (fun t1 t2 ->
-        let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name in
-
-        let package = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, string) ) t1.package t2.package in
-
-        let dependency = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (3, string, not_packed) ) t1.dependency t2.dependency in
-
-        let message_type = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (4, (message ((fun writer -> DescriptorProto.from_proto_exn writer), DescriptorProto.merge)), not_packed) ) t1.message_type t2.message_type in
-
-        let enum_type = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (5, (message ((fun writer -> EnumDescriptorProto.from_proto_exn writer), EnumDescriptorProto.merge)), not_packed) ) t1.enum_type t2.enum_type in
-
-        let service = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (6, (message ((fun writer -> ServiceDescriptorProto.from_proto_exn writer), ServiceDescriptorProto.merge)), not_packed) ) t1.service t2.service in
-
-        let extension = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (7, (message ((fun writer -> FieldDescriptorProto.from_proto_exn writer), FieldDescriptorProto.merge)), not_packed) ) t1.extension t2.extension in
-
-        let options = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (8, (message ((fun writer -> FileOptions.from_proto_exn writer), FileOptions.merge))) ) t1.options t2.options in
-
-        let source_code_info = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (9, (message ((fun writer -> SourceCodeInfo.from_proto_exn writer), SourceCodeInfo.merge))) ) t1.source_code_info t2.source_code_info in
-
-        let public_dependency = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (10, int32_int, not_packed) ) t1.public_dependency t2.public_dependency in
-
-        let weak_dependency = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (11, int32_int, not_packed) ) t1.weak_dependency t2.weak_dependency in
-
-        let syntax = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (12, string) ) t1.syntax t2.syntax in
-
-        { name; package; dependency; message_type; enum_type; service; extension; options; source_code_info; public_dependency; weak_dependency; syntax })
+      let merge = (fun t1 t2 -> {
+        name = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name);
+        package = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, string) ) t1.package t2.package);
+        dependency = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (3, string, not_packed) ) t1.dependency t2.dependency);
+        message_type = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (4, (message ((fun writer -> DescriptorProto.from_proto_exn writer), DescriptorProto.merge)), not_packed) ) t1.message_type t2.message_type);
+        enum_type = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (5, (message ((fun writer -> EnumDescriptorProto.from_proto_exn writer), EnumDescriptorProto.merge)), not_packed) ) t1.enum_type t2.enum_type);
+        service = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (6, (message ((fun writer -> ServiceDescriptorProto.from_proto_exn writer), ServiceDescriptorProto.merge)), not_packed) ) t1.service t2.service);
+        extension = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (7, (message ((fun writer -> FieldDescriptorProto.from_proto_exn writer), FieldDescriptorProto.merge)), not_packed) ) t1.extension t2.extension);
+        options = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (8, (message ((fun writer -> FileOptions.from_proto_exn writer), FileOptions.merge))) ) t1.options t2.options);
+        source_code_info = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (9, (message ((fun writer -> SourceCodeInfo.from_proto_exn writer), SourceCodeInfo.merge))) ) t1.source_code_info t2.source_code_info);
+        public_dependency = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (10, int32_int, not_packed) ) t1.public_dependency t2.public_dependency);
+        weak_dependency = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (11, int32_int, not_packed) ) t1.weak_dependency t2.weak_dependency);
+        syntax = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (12, string) ) t1.syntax t2.syntax);
+         })
       let to_proto' =
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: repeated (3, string, not_packed) ^:: repeated (4, (message DescriptorProto.to_proto'), not_packed) ^:: repeated (5, (message EnumDescriptorProto.to_proto'), not_packed) ^:: repeated (6, (message ServiceDescriptorProto.to_proto'), not_packed) ^:: repeated (7, (message FieldDescriptorProto.to_proto'), not_packed) ^:: basic_opt (8, (message FileOptions.to_proto')) ^:: basic_opt (9, (message SourceCodeInfo.to_proto')) ^:: repeated (10, int32_int, not_packed) ^:: repeated (11, int32_int, not_packed) ^:: basic_opt (12, string) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
@@ -759,14 +744,11 @@ end = struct
         let name' () = "descriptor.google.protobuf.DescriptorProto.ExtensionRange"
         type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
         let make ?start ?end' ?options () = { start; end'; options }
-        let merge = (fun t1 t2 ->
-          let start = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, int32_int) ) t1.start t2.start in
-
-          let end' = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, int32_int) ) t1.end' t2.end' in
-
-          let options = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, (message ((fun writer -> ExtensionRangeOptions.from_proto_exn writer), ExtensionRangeOptions.merge))) ) t1.options t2.options in
-
-          { start; end'; options })
+        let merge = (fun t1 t2 -> {
+          start = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, int32_int) ) t1.start t2.start);
+          end' = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, int32_int) ) t1.end' t2.end');
+          options = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, (message ((fun writer -> ExtensionRangeOptions.from_proto_exn writer), ExtensionRangeOptions.merge))) ) t1.options t2.options);
+           })
         let to_proto' =
           let spec = Runtime'.Serialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, (message ExtensionRangeOptions.to_proto')) ^:: nil ) in
           let serialize = Runtime'.Serialize.serialize spec in
@@ -792,12 +774,10 @@ end = struct
         let name' () = "descriptor.google.protobuf.DescriptorProto.ReservedRange"
         type t = { start: int option; end': int option }
         let make ?start ?end' () = { start; end' }
-        let merge = (fun t1 t2 ->
-          let start = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, int32_int) ) t1.start t2.start in
-
-          let end' = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, int32_int) ) t1.end' t2.end' in
-
-          { start; end' })
+        let merge = (fun t1 t2 -> {
+          start = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, int32_int) ) t1.start t2.start);
+          end' = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, int32_int) ) t1.end' t2.end');
+           })
         let to_proto' =
           let spec = Runtime'.Serialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: nil ) in
           let serialize = Runtime'.Serialize.serialize spec in
@@ -813,28 +793,18 @@ end = struct
       let name' () = "descriptor.google.protobuf.DescriptorProto"
       type t = { name: string option; field: FieldDescriptorProto.t list; nested_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; extension_range: ExtensionRange.t list; extension: FieldDescriptorProto.t list; options: MessageOptions.t option; oneof_decl: OneofDescriptorProto.t list; reserved_range: ReservedRange.t list; reserved_name: string list }
       let make ?name ?(field = []) ?(nested_type = []) ?(enum_type = []) ?(extension_range = []) ?(extension = []) ?options ?(oneof_decl = []) ?(reserved_range = []) ?(reserved_name = []) () = { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name }
-      let merge = (fun t1 t2 ->
-        let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name in
-
-        let field = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (2, (message ((fun writer -> FieldDescriptorProto.from_proto_exn writer), FieldDescriptorProto.merge)), not_packed) ) t1.field t2.field in
-
-        let nested_type = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (3, (message ((fun writer -> DescriptorProto.from_proto_exn writer), DescriptorProto.merge)), not_packed) ) t1.nested_type t2.nested_type in
-
-        let enum_type = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (4, (message ((fun writer -> EnumDescriptorProto.from_proto_exn writer), EnumDescriptorProto.merge)), not_packed) ) t1.enum_type t2.enum_type in
-
-        let extension_range = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (5, (message ((fun writer -> ExtensionRange.from_proto_exn writer), ExtensionRange.merge)), not_packed) ) t1.extension_range t2.extension_range in
-
-        let extension = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (6, (message ((fun writer -> FieldDescriptorProto.from_proto_exn writer), FieldDescriptorProto.merge)), not_packed) ) t1.extension t2.extension in
-
-        let options = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (7, (message ((fun writer -> MessageOptions.from_proto_exn writer), MessageOptions.merge))) ) t1.options t2.options in
-
-        let oneof_decl = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (8, (message ((fun writer -> OneofDescriptorProto.from_proto_exn writer), OneofDescriptorProto.merge)), not_packed) ) t1.oneof_decl t2.oneof_decl in
-
-        let reserved_range = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (9, (message ((fun writer -> ReservedRange.from_proto_exn writer), ReservedRange.merge)), not_packed) ) t1.reserved_range t2.reserved_range in
-
-        let reserved_name = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (10, string, not_packed) ) t1.reserved_name t2.reserved_name in
-
-        { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name })
+      let merge = (fun t1 t2 -> {
+        name = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name);
+        field = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (2, (message ((fun writer -> FieldDescriptorProto.from_proto_exn writer), FieldDescriptorProto.merge)), not_packed) ) t1.field t2.field);
+        nested_type = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (3, (message ((fun writer -> DescriptorProto.from_proto_exn writer), DescriptorProto.merge)), not_packed) ) t1.nested_type t2.nested_type);
+        enum_type = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (4, (message ((fun writer -> EnumDescriptorProto.from_proto_exn writer), EnumDescriptorProto.merge)), not_packed) ) t1.enum_type t2.enum_type);
+        extension_range = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (5, (message ((fun writer -> ExtensionRange.from_proto_exn writer), ExtensionRange.merge)), not_packed) ) t1.extension_range t2.extension_range);
+        extension = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (6, (message ((fun writer -> FieldDescriptorProto.from_proto_exn writer), FieldDescriptorProto.merge)), not_packed) ) t1.extension t2.extension);
+        options = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (7, (message ((fun writer -> MessageOptions.from_proto_exn writer), MessageOptions.merge))) ) t1.options t2.options);
+        oneof_decl = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (8, (message ((fun writer -> OneofDescriptorProto.from_proto_exn writer), OneofDescriptorProto.merge)), not_packed) ) t1.oneof_decl t2.oneof_decl);
+        reserved_range = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (9, (message ((fun writer -> ReservedRange.from_proto_exn writer), ReservedRange.merge)), not_packed) ) t1.reserved_range t2.reserved_range);
+        reserved_name = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (10, string, not_packed) ) t1.reserved_name t2.reserved_name);
+         })
       let to_proto' =
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: repeated (2, (message FieldDescriptorProto.to_proto'), not_packed) ^:: repeated (3, (message DescriptorProto.to_proto'), not_packed) ^:: repeated (4, (message EnumDescriptorProto.to_proto'), not_packed) ^:: repeated (5, (message ExtensionRange.to_proto'), not_packed) ^:: repeated (6, (message FieldDescriptorProto.to_proto'), not_packed) ^:: basic_opt (7, (message MessageOptions.to_proto')) ^:: repeated (8, (message OneofDescriptorProto.to_proto'), not_packed) ^:: repeated (9, (message ReservedRange.to_proto'), not_packed) ^:: repeated (10, string, not_packed) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
@@ -860,11 +830,10 @@ end = struct
       let name' () = "descriptor.google.protobuf.ExtensionRangeOptions"
       type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { uninterpreted_option; extensions' }
-      let merge = (fun t1 t2 ->
-        let uninterpreted_option = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option in
-
-        let extensions' = List.append t1.extensions' t2.extensions' in
-        { uninterpreted_option; extensions' })
+      let merge = (fun t1 t2 -> {
+        uninterpreted_option = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option);
+        extensions' = (List.append t1.extensions' t2.extensions');
+         })
       let to_proto' =
         let spec = Runtime'.Serialize.C.( repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         let serialize = Runtime'.Serialize.serialize spec in
@@ -972,30 +941,19 @@ end = struct
       let name' () = "descriptor.google.protobuf.FieldDescriptorProto"
       type t = { name: string option; extendee: string option; number: int option; label: Label.t option; type': Type.t option; type_name: string option; default_value: string option; options: FieldOptions.t option; oneof_index: int option; json_name: string option; proto3_optional: bool option }
       let make ?name ?extendee ?number ?label ?type' ?type_name ?default_value ?options ?oneof_index ?json_name ?proto3_optional () = { name; extendee; number; label; type'; type_name; default_value; options; oneof_index; json_name; proto3_optional }
-      let merge = (fun t1 t2 ->
-        let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name in
-
-        let extendee = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, string) ) t1.extendee t2.extendee in
-
-        let number = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, int32_int) ) t1.number t2.number in
-
-        let label = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (4, (enum Label.from_int_exn)) ) t1.label t2.label in
-
-        let type' = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (5, (enum Type.from_int_exn)) ) t1.type' t2.type' in
-
-        let type_name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (6, string) ) t1.type_name t2.type_name in
-
-        let default_value = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (7, string) ) t1.default_value t2.default_value in
-
-        let options = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (8, (message ((fun writer -> FieldOptions.from_proto_exn writer), FieldOptions.merge))) ) t1.options t2.options in
-
-        let oneof_index = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (9, int32_int) ) t1.oneof_index t2.oneof_index in
-
-        let json_name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (10, string) ) t1.json_name t2.json_name in
-
-        let proto3_optional = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (17, bool) ) t1.proto3_optional t2.proto3_optional in
-
-        { name; extendee; number; label; type'; type_name; default_value; options; oneof_index; json_name; proto3_optional })
+      let merge = (fun t1 t2 -> {
+        name = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name);
+        extendee = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, string) ) t1.extendee t2.extendee);
+        number = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, int32_int) ) t1.number t2.number);
+        label = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (4, (enum Label.from_int_exn)) ) t1.label t2.label);
+        type' = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (5, (enum Type.from_int_exn)) ) t1.type' t2.type');
+        type_name = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (6, string) ) t1.type_name t2.type_name);
+        default_value = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (7, string) ) t1.default_value t2.default_value);
+        options = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (8, (message ((fun writer -> FieldOptions.from_proto_exn writer), FieldOptions.merge))) ) t1.options t2.options);
+        oneof_index = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (9, int32_int) ) t1.oneof_index t2.oneof_index);
+        json_name = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (10, string) ) t1.json_name t2.json_name);
+        proto3_optional = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (17, bool) ) t1.proto3_optional t2.proto3_optional);
+         })
       let to_proto' =
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, (enum Label.to_int)) ^:: basic_opt (5, (enum Type.to_int)) ^:: basic_opt (6, string) ^:: basic_opt (7, string) ^:: basic_opt (8, (message FieldOptions.to_proto')) ^:: basic_opt (9, int32_int) ^:: basic_opt (10, string) ^:: basic_opt (17, bool) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
@@ -1021,12 +979,10 @@ end = struct
       let name' () = "descriptor.google.protobuf.OneofDescriptorProto"
       type t = { name: string option; options: OneofOptions.t option }
       let make ?name ?options () = { name; options }
-      let merge = (fun t1 t2 ->
-        let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name in
-
-        let options = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, (message ((fun writer -> OneofOptions.from_proto_exn writer), OneofOptions.merge))) ) t1.options t2.options in
-
-        { name; options })
+      let merge = (fun t1 t2 -> {
+        name = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name);
+        options = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, (message ((fun writer -> OneofOptions.from_proto_exn writer), OneofOptions.merge))) ) t1.options t2.options);
+         })
       let to_proto' =
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, (message OneofOptions.to_proto')) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
@@ -1072,12 +1028,10 @@ end = struct
         let name' () = "descriptor.google.protobuf.EnumDescriptorProto.EnumReservedRange"
         type t = { start: int option; end': int option }
         let make ?start ?end' () = { start; end' }
-        let merge = (fun t1 t2 ->
-          let start = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, int32_int) ) t1.start t2.start in
-
-          let end' = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, int32_int) ) t1.end' t2.end' in
-
-          { start; end' })
+        let merge = (fun t1 t2 -> {
+          start = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, int32_int) ) t1.start t2.start);
+          end' = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, int32_int) ) t1.end' t2.end');
+           })
         let to_proto' =
           let spec = Runtime'.Serialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: nil ) in
           let serialize = Runtime'.Serialize.serialize spec in
@@ -1093,18 +1047,13 @@ end = struct
       let name' () = "descriptor.google.protobuf.EnumDescriptorProto"
       type t = { name: string option; value: EnumValueDescriptorProto.t list; options: EnumOptions.t option; reserved_range: EnumReservedRange.t list; reserved_name: string list }
       let make ?name ?(value = []) ?options ?(reserved_range = []) ?(reserved_name = []) () = { name; value; options; reserved_range; reserved_name }
-      let merge = (fun t1 t2 ->
-        let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name in
-
-        let value = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (2, (message ((fun writer -> EnumValueDescriptorProto.from_proto_exn writer), EnumValueDescriptorProto.merge)), not_packed) ) t1.value t2.value in
-
-        let options = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, (message ((fun writer -> EnumOptions.from_proto_exn writer), EnumOptions.merge))) ) t1.options t2.options in
-
-        let reserved_range = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (4, (message ((fun writer -> EnumReservedRange.from_proto_exn writer), EnumReservedRange.merge)), not_packed) ) t1.reserved_range t2.reserved_range in
-
-        let reserved_name = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (5, string, not_packed) ) t1.reserved_name t2.reserved_name in
-
-        { name; value; options; reserved_range; reserved_name })
+      let merge = (fun t1 t2 -> {
+        name = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name);
+        value = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (2, (message ((fun writer -> EnumValueDescriptorProto.from_proto_exn writer), EnumValueDescriptorProto.merge)), not_packed) ) t1.value t2.value);
+        options = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, (message ((fun writer -> EnumOptions.from_proto_exn writer), EnumOptions.merge))) ) t1.options t2.options);
+        reserved_range = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (4, (message ((fun writer -> EnumReservedRange.from_proto_exn writer), EnumReservedRange.merge)), not_packed) ) t1.reserved_range t2.reserved_range);
+        reserved_name = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (5, string, not_packed) ) t1.reserved_name t2.reserved_name);
+         })
       let to_proto' =
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: repeated (2, (message EnumValueDescriptorProto.to_proto'), not_packed) ^:: basic_opt (3, (message EnumOptions.to_proto')) ^:: repeated (4, (message EnumReservedRange.to_proto'), not_packed) ^:: repeated (5, string, not_packed) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
@@ -1130,14 +1079,11 @@ end = struct
       let name' () = "descriptor.google.protobuf.EnumValueDescriptorProto"
       type t = { name: string option; number: int option; options: EnumValueOptions.t option }
       let make ?name ?number ?options () = { name; number; options }
-      let merge = (fun t1 t2 ->
-        let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name in
-
-        let number = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, int32_int) ) t1.number t2.number in
-
-        let options = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, (message ((fun writer -> EnumValueOptions.from_proto_exn writer), EnumValueOptions.merge))) ) t1.options t2.options in
-
-        { name; number; options })
+      let merge = (fun t1 t2 -> {
+        name = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name);
+        number = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, int32_int) ) t1.number t2.number);
+        options = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, (message ((fun writer -> EnumValueOptions.from_proto_exn writer), EnumValueOptions.merge))) ) t1.options t2.options);
+         })
       let to_proto' =
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, (message EnumValueOptions.to_proto')) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
@@ -1163,14 +1109,11 @@ end = struct
       let name' () = "descriptor.google.protobuf.ServiceDescriptorProto"
       type t = { name: string option; method': MethodDescriptorProto.t list; options: ServiceOptions.t option }
       let make ?name ?(method' = []) ?options () = { name; method'; options }
-      let merge = (fun t1 t2 ->
-        let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name in
-
-        let method' = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (2, (message ((fun writer -> MethodDescriptorProto.from_proto_exn writer), MethodDescriptorProto.merge)), not_packed) ) t1.method' t2.method' in
-
-        let options = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, (message ((fun writer -> ServiceOptions.from_proto_exn writer), ServiceOptions.merge))) ) t1.options t2.options in
-
-        { name; method'; options })
+      let merge = (fun t1 t2 -> {
+        name = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name);
+        method' = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (2, (message ((fun writer -> MethodDescriptorProto.from_proto_exn writer), MethodDescriptorProto.merge)), not_packed) ) t1.method' t2.method');
+        options = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, (message ((fun writer -> ServiceOptions.from_proto_exn writer), ServiceOptions.merge))) ) t1.options t2.options);
+         })
       let to_proto' =
         let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: repeated (2, (message MethodDescriptorProto.to_proto'), not_packed) ^:: basic_opt (3, (message ServiceOptions.to_proto')) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
@@ -1196,29 +1139,23 @@ end = struct
       let name' () = "descriptor.google.protobuf.MethodDescriptorProto"
       type t = { name: string option; input_type: string option; output_type: string option; options: MethodOptions.t option; client_streaming: bool; server_streaming: bool }
       let make ?name ?input_type ?output_type ?options ?(client_streaming = false) ?(server_streaming = false) () = { name; input_type; output_type; options; client_streaming; server_streaming }
-      let merge = (fun t1 t2 ->
-        let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name in
-
-        let input_type = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, string) ) t1.input_type t2.input_type in
-
-        let output_type = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, string) ) t1.output_type t2.output_type in
-
-        let options = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (4, (message ((fun writer -> MethodOptions.from_proto_exn writer), MethodOptions.merge))) ) t1.options t2.options in
-
-        let client_streaming = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (5, bool, Some (false)) ) t1.client_streaming t2.client_streaming in
-
-        let server_streaming = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (6, bool, Some (false)) ) t1.server_streaming t2.server_streaming in
-
-        { name; input_type; output_type; options; client_streaming; server_streaming })
+      let merge = (fun t1 t2 -> {
+        name = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name);
+        input_type = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, string) ) t1.input_type t2.input_type);
+        output_type = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, string) ) t1.output_type t2.output_type);
+        options = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (4, (message ((fun writer -> MethodOptions.from_proto_exn writer), MethodOptions.merge))) ) t1.options t2.options);
+        client_streaming = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (5, bool, (false)) ) t1.client_streaming t2.client_streaming);
+        server_streaming = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (6, bool, (false)) ) t1.server_streaming t2.server_streaming);
+         })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, string) ^:: basic_opt (4, (message MethodOptions.to_proto')) ^:: basic (5, bool, Some (false)) ^:: basic (6, bool, Some (false)) ^:: nil ) in
+        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, string) ^:: basic_opt (4, (message MethodOptions.to_proto')) ^:: basic (5, bool, (false)) ^:: basic (6, bool, (false)) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { name; input_type; output_type; options; client_streaming; server_streaming } -> serialize writer name input_type output_type options client_streaming server_streaming
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun name input_type output_type options client_streaming server_streaming -> { name; input_type; output_type; options; client_streaming; server_streaming } in
-        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, string) ^:: basic_opt (4, (message ((fun writer -> MethodOptions.from_proto_exn writer), MethodOptions.merge))) ^:: basic (5, bool, Some (false)) ^:: basic (6, bool, Some (false)) ^:: nil ) in
+        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (3, string) ^:: basic_opt (4, (message ((fun writer -> MethodOptions.from_proto_exn writer), MethodOptions.merge))) ^:: basic (5, bool, (false)) ^:: basic (6, bool, (false)) ^:: nil ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1261,60 +1198,39 @@ end = struct
       let name' () = "descriptor.google.protobuf.FileOptions"
       type t = { java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?java_package ?java_outer_classname ?(optimize_for = OptimizeMode.SPEED) ?(java_multiple_files = false) ?go_package ?(cc_generic_services = false) ?(java_generic_services = false) ?(py_generic_services = false) ?java_generate_equals_and_hash ?(deprecated = false) ?(java_string_check_utf8 = false) ?(cc_enable_arenas = true) ?objc_class_prefix ?csharp_namespace ?swift_prefix ?php_class_prefix ?php_namespace ?(php_generic_services = false) ?php_metadata_namespace ?ruby_package ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { java_package; java_outer_classname; optimize_for; java_multiple_files; go_package; cc_generic_services; java_generic_services; py_generic_services; java_generate_equals_and_hash; deprecated; java_string_check_utf8; cc_enable_arenas; objc_class_prefix; csharp_namespace; swift_prefix; php_class_prefix; php_namespace; php_generic_services; php_metadata_namespace; ruby_package; uninterpreted_option; extensions' }
-      let merge = (fun t1 t2 ->
-        let java_package = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.java_package t2.java_package in
-
-        let java_outer_classname = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (8, string) ) t1.java_outer_classname t2.java_outer_classname in
-
-        let optimize_for = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (9, (enum OptimizeMode.from_int_exn), Some (OptimizeMode.SPEED)) ) t1.optimize_for t2.optimize_for in
-
-        let java_multiple_files = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (10, bool, Some (false)) ) t1.java_multiple_files t2.java_multiple_files in
-
-        let go_package = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (11, string) ) t1.go_package t2.go_package in
-
-        let cc_generic_services = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (16, bool, Some (false)) ) t1.cc_generic_services t2.cc_generic_services in
-
-        let java_generic_services = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (17, bool, Some (false)) ) t1.java_generic_services t2.java_generic_services in
-
-        let py_generic_services = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (18, bool, Some (false)) ) t1.py_generic_services t2.py_generic_services in
-
-        let java_generate_equals_and_hash = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (20, bool) ) t1.java_generate_equals_and_hash t2.java_generate_equals_and_hash in
-
-        let deprecated = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (23, bool, Some (false)) ) t1.deprecated t2.deprecated in
-
-        let java_string_check_utf8 = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (27, bool, Some (false)) ) t1.java_string_check_utf8 t2.java_string_check_utf8 in
-
-        let cc_enable_arenas = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (31, bool, Some (true)) ) t1.cc_enable_arenas t2.cc_enable_arenas in
-
-        let objc_class_prefix = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (36, string) ) t1.objc_class_prefix t2.objc_class_prefix in
-
-        let csharp_namespace = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (37, string) ) t1.csharp_namespace t2.csharp_namespace in
-
-        let swift_prefix = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (39, string) ) t1.swift_prefix t2.swift_prefix in
-
-        let php_class_prefix = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (40, string) ) t1.php_class_prefix t2.php_class_prefix in
-
-        let php_namespace = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (41, string) ) t1.php_namespace t2.php_namespace in
-
-        let php_generic_services = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (42, bool, Some (false)) ) t1.php_generic_services t2.php_generic_services in
-
-        let php_metadata_namespace = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (44, string) ) t1.php_metadata_namespace t2.php_metadata_namespace in
-
-        let ruby_package = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (45, string) ) t1.ruby_package t2.ruby_package in
-
-        let uninterpreted_option = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option in
-
-        let extensions' = List.append t1.extensions' t2.extensions' in
-        { java_package; java_outer_classname; optimize_for; java_multiple_files; go_package; cc_generic_services; java_generic_services; py_generic_services; java_generate_equals_and_hash; deprecated; java_string_check_utf8; cc_enable_arenas; objc_class_prefix; csharp_namespace; swift_prefix; php_class_prefix; php_namespace; php_generic_services; php_metadata_namespace; ruby_package; uninterpreted_option; extensions' })
+      let merge = (fun t1 t2 -> {
+        java_package = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.java_package t2.java_package);
+        java_outer_classname = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (8, string) ) t1.java_outer_classname t2.java_outer_classname);
+        optimize_for = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (9, (enum OptimizeMode.from_int_exn), (OptimizeMode.SPEED)) ) t1.optimize_for t2.optimize_for);
+        java_multiple_files = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (10, bool, (false)) ) t1.java_multiple_files t2.java_multiple_files);
+        go_package = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (11, string) ) t1.go_package t2.go_package);
+        cc_generic_services = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (16, bool, (false)) ) t1.cc_generic_services t2.cc_generic_services);
+        java_generic_services = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (17, bool, (false)) ) t1.java_generic_services t2.java_generic_services);
+        py_generic_services = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (18, bool, (false)) ) t1.py_generic_services t2.py_generic_services);
+        java_generate_equals_and_hash = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (20, bool) ) t1.java_generate_equals_and_hash t2.java_generate_equals_and_hash);
+        deprecated = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (23, bool, (false)) ) t1.deprecated t2.deprecated);
+        java_string_check_utf8 = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (27, bool, (false)) ) t1.java_string_check_utf8 t2.java_string_check_utf8);
+        cc_enable_arenas = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (31, bool, (true)) ) t1.cc_enable_arenas t2.cc_enable_arenas);
+        objc_class_prefix = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (36, string) ) t1.objc_class_prefix t2.objc_class_prefix);
+        csharp_namespace = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (37, string) ) t1.csharp_namespace t2.csharp_namespace);
+        swift_prefix = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (39, string) ) t1.swift_prefix t2.swift_prefix);
+        php_class_prefix = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (40, string) ) t1.php_class_prefix t2.php_class_prefix);
+        php_namespace = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (41, string) ) t1.php_namespace t2.php_namespace);
+        php_generic_services = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (42, bool, (false)) ) t1.php_generic_services t2.php_generic_services);
+        php_metadata_namespace = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (44, string) ) t1.php_metadata_namespace t2.php_metadata_namespace);
+        ruby_package = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (45, string) ) t1.ruby_package t2.ruby_package);
+        uninterpreted_option = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option);
+        extensions' = (List.append t1.extensions' t2.extensions');
+         })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (8, string) ^:: basic (9, (enum OptimizeMode.to_int), Some (OptimizeMode.SPEED)) ^:: basic (10, bool, Some (false)) ^:: basic_opt (11, string) ^:: basic (16, bool, Some (false)) ^:: basic (17, bool, Some (false)) ^:: basic (18, bool, Some (false)) ^:: basic_opt (20, bool) ^:: basic (23, bool, Some (false)) ^:: basic (27, bool, Some (false)) ^:: basic (31, bool, Some (true)) ^:: basic_opt (36, string) ^:: basic_opt (37, string) ^:: basic_opt (39, string) ^:: basic_opt (40, string) ^:: basic_opt (41, string) ^:: basic (42, bool, Some (false)) ^:: basic_opt (44, string) ^:: basic_opt (45, string) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (8, string) ^:: basic (9, (enum OptimizeMode.to_int), (OptimizeMode.SPEED)) ^:: basic (10, bool, (false)) ^:: basic_opt (11, string) ^:: basic (16, bool, (false)) ^:: basic (17, bool, (false)) ^:: basic (18, bool, (false)) ^:: basic_opt (20, bool) ^:: basic (23, bool, (false)) ^:: basic (27, bool, (false)) ^:: basic (31, bool, (true)) ^:: basic_opt (36, string) ^:: basic_opt (37, string) ^:: basic_opt (39, string) ^:: basic_opt (40, string) ^:: basic_opt (41, string) ^:: basic (42, bool, (false)) ^:: basic_opt (44, string) ^:: basic_opt (45, string) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { java_package; java_outer_classname; optimize_for; java_multiple_files; go_package; cc_generic_services; java_generic_services; py_generic_services; java_generate_equals_and_hash; deprecated; java_string_check_utf8; cc_enable_arenas; objc_class_prefix; csharp_namespace; swift_prefix; php_class_prefix; php_namespace; php_generic_services; php_metadata_namespace; ruby_package; uninterpreted_option; extensions' } -> serialize writer java_package java_outer_classname optimize_for java_multiple_files go_package cc_generic_services java_generic_services py_generic_services java_generate_equals_and_hash deprecated java_string_check_utf8 cc_enable_arenas objc_class_prefix csharp_namespace swift_prefix php_class_prefix php_namespace php_generic_services php_metadata_namespace ruby_package uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun java_package java_outer_classname optimize_for java_multiple_files go_package cc_generic_services java_generic_services py_generic_services java_generate_equals_and_hash deprecated java_string_check_utf8 cc_enable_arenas objc_class_prefix csharp_namespace swift_prefix php_class_prefix php_namespace php_generic_services php_metadata_namespace ruby_package uninterpreted_option extensions' -> { java_package; java_outer_classname; optimize_for; java_multiple_files; go_package; cc_generic_services; java_generic_services; py_generic_services; java_generate_equals_and_hash; deprecated; java_string_check_utf8; cc_enable_arenas; objc_class_prefix; csharp_namespace; swift_prefix; php_class_prefix; php_namespace; php_generic_services; php_metadata_namespace; ruby_package; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (8, string) ^:: basic (9, (enum OptimizeMode.from_int_exn), Some (OptimizeMode.SPEED)) ^:: basic (10, bool, Some (false)) ^:: basic_opt (11, string) ^:: basic (16, bool, Some (false)) ^:: basic (17, bool, Some (false)) ^:: basic (18, bool, Some (false)) ^:: basic_opt (20, bool) ^:: basic (23, bool, Some (false)) ^:: basic (27, bool, Some (false)) ^:: basic (31, bool, Some (true)) ^:: basic_opt (36, string) ^:: basic_opt (37, string) ^:: basic_opt (39, string) ^:: basic_opt (40, string) ^:: basic_opt (41, string) ^:: basic (42, bool, Some (false)) ^:: basic_opt (44, string) ^:: basic_opt (45, string) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (8, string) ^:: basic (9, (enum OptimizeMode.from_int_exn), (OptimizeMode.SPEED)) ^:: basic (10, bool, (false)) ^:: basic_opt (11, string) ^:: basic (16, bool, (false)) ^:: basic (17, bool, (false)) ^:: basic (18, bool, (false)) ^:: basic_opt (20, bool) ^:: basic (23, bool, (false)) ^:: basic (27, bool, (false)) ^:: basic (31, bool, (true)) ^:: basic_opt (36, string) ^:: basic_opt (37, string) ^:: basic_opt (39, string) ^:: basic_opt (40, string) ^:: basic_opt (41, string) ^:: basic (42, bool, (false)) ^:: basic_opt (44, string) ^:: basic_opt (45, string) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1331,28 +1247,23 @@ end = struct
       let name' () = "descriptor.google.protobuf.MessageOptions"
       type t = { message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(message_set_wire_format = false) ?(no_standard_descriptor_accessor = false) ?(deprecated = false) ?map_entry ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { message_set_wire_format; no_standard_descriptor_accessor; deprecated; map_entry; uninterpreted_option; extensions' }
-      let merge = (fun t1 t2 ->
-        let message_set_wire_format = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ) t1.message_set_wire_format t2.message_set_wire_format in
-
-        let no_standard_descriptor_accessor = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (2, bool, Some (false)) ) t1.no_standard_descriptor_accessor t2.no_standard_descriptor_accessor in
-
-        let deprecated = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (3, bool, Some (false)) ) t1.deprecated t2.deprecated in
-
-        let map_entry = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (7, bool) ) t1.map_entry t2.map_entry in
-
-        let uninterpreted_option = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option in
-
-        let extensions' = List.append t1.extensions' t2.extensions' in
-        { message_set_wire_format; no_standard_descriptor_accessor; deprecated; map_entry; uninterpreted_option; extensions' })
+      let merge = (fun t1 t2 -> {
+        message_set_wire_format = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (1, bool, (false)) ) t1.message_set_wire_format t2.message_set_wire_format);
+        no_standard_descriptor_accessor = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (2, bool, (false)) ) t1.no_standard_descriptor_accessor t2.no_standard_descriptor_accessor);
+        deprecated = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (3, bool, (false)) ) t1.deprecated t2.deprecated);
+        map_entry = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (7, bool) ) t1.map_entry t2.map_entry);
+        uninterpreted_option = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option);
+        extensions' = (List.append t1.extensions' t2.extensions');
+         })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic (1, bool, Some (false)) ^:: basic (2, bool, Some (false)) ^:: basic (3, bool, Some (false)) ^:: basic_opt (7, bool) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Serialize.C.( basic (1, bool, (false)) ^:: basic (2, bool, (false)) ^:: basic (3, bool, (false)) ^:: basic_opt (7, bool) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { message_set_wire_format; no_standard_descriptor_accessor; deprecated; map_entry; uninterpreted_option; extensions' } -> serialize writer message_set_wire_format no_standard_descriptor_accessor deprecated map_entry uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun message_set_wire_format no_standard_descriptor_accessor deprecated map_entry uninterpreted_option extensions' -> { message_set_wire_format; no_standard_descriptor_accessor; deprecated; map_entry; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ^:: basic (2, bool, Some (false)) ^:: basic (3, bool, Some (false)) ^:: basic_opt (7, bool) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Deserialize.C.( basic (1, bool, (false)) ^:: basic (2, bool, (false)) ^:: basic (3, bool, (false)) ^:: basic_opt (7, bool) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1421,34 +1332,26 @@ end = struct
       let name' () = "descriptor.google.protobuf.FieldOptions"
       type t = { ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(ctype = CType.STRING) ?packed ?(deprecated = false) ?(lazy' = false) ?(jstype = JSType.JS_NORMAL) ?(weak = false) ?(unverified_lazy = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { ctype; packed; deprecated; lazy'; jstype; weak; unverified_lazy; uninterpreted_option; extensions' }
-      let merge = (fun t1 t2 ->
-        let ctype = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (1, (enum CType.from_int_exn), Some (CType.STRING)) ) t1.ctype t2.ctype in
-
-        let packed = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, bool) ) t1.packed t2.packed in
-
-        let deprecated = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (3, bool, Some (false)) ) t1.deprecated t2.deprecated in
-
-        let lazy' = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (5, bool, Some (false)) ) t1.lazy' t2.lazy' in
-
-        let jstype = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (6, (enum JSType.from_int_exn), Some (JSType.JS_NORMAL)) ) t1.jstype t2.jstype in
-
-        let weak = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (10, bool, Some (false)) ) t1.weak t2.weak in
-
-        let unverified_lazy = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (15, bool, Some (false)) ) t1.unverified_lazy t2.unverified_lazy in
-
-        let uninterpreted_option = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option in
-
-        let extensions' = List.append t1.extensions' t2.extensions' in
-        { ctype; packed; deprecated; lazy'; jstype; weak; unverified_lazy; uninterpreted_option; extensions' })
+      let merge = (fun t1 t2 -> {
+        ctype = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (1, (enum CType.from_int_exn), (CType.STRING)) ) t1.ctype t2.ctype);
+        packed = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, bool) ) t1.packed t2.packed);
+        deprecated = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (3, bool, (false)) ) t1.deprecated t2.deprecated);
+        lazy' = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (5, bool, (false)) ) t1.lazy' t2.lazy');
+        jstype = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (6, (enum JSType.from_int_exn), (JSType.JS_NORMAL)) ) t1.jstype t2.jstype);
+        weak = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (10, bool, (false)) ) t1.weak t2.weak);
+        unverified_lazy = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (15, bool, (false)) ) t1.unverified_lazy t2.unverified_lazy);
+        uninterpreted_option = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option);
+        extensions' = (List.append t1.extensions' t2.extensions');
+         })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic (1, (enum CType.to_int), Some (CType.STRING)) ^:: basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: basic (5, bool, Some (false)) ^:: basic (6, (enum JSType.to_int), Some (JSType.JS_NORMAL)) ^:: basic (10, bool, Some (false)) ^:: basic (15, bool, Some (false)) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Serialize.C.( basic (1, (enum CType.to_int), (CType.STRING)) ^:: basic_opt (2, bool) ^:: basic (3, bool, (false)) ^:: basic (5, bool, (false)) ^:: basic (6, (enum JSType.to_int), (JSType.JS_NORMAL)) ^:: basic (10, bool, (false)) ^:: basic (15, bool, (false)) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { ctype; packed; deprecated; lazy'; jstype; weak; unverified_lazy; uninterpreted_option; extensions' } -> serialize writer ctype packed deprecated lazy' jstype weak unverified_lazy uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun ctype packed deprecated lazy' jstype weak unverified_lazy uninterpreted_option extensions' -> { ctype; packed; deprecated; lazy'; jstype; weak; unverified_lazy; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (1, (enum CType.from_int_exn), Some (CType.STRING)) ^:: basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: basic (5, bool, Some (false)) ^:: basic (6, (enum JSType.from_int_exn), Some (JSType.JS_NORMAL)) ^:: basic (10, bool, Some (false)) ^:: basic (15, bool, Some (false)) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Deserialize.C.( basic (1, (enum CType.from_int_exn), (CType.STRING)) ^:: basic_opt (2, bool) ^:: basic (3, bool, (false)) ^:: basic (5, bool, (false)) ^:: basic (6, (enum JSType.from_int_exn), (JSType.JS_NORMAL)) ^:: basic (10, bool, (false)) ^:: basic (15, bool, (false)) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1465,11 +1368,10 @@ end = struct
       let name' () = "descriptor.google.protobuf.OneofOptions"
       type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { uninterpreted_option; extensions' }
-      let merge = (fun t1 t2 ->
-        let uninterpreted_option = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option in
-
-        let extensions' = List.append t1.extensions' t2.extensions' in
-        { uninterpreted_option; extensions' })
+      let merge = (fun t1 t2 -> {
+        uninterpreted_option = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option);
+        extensions' = (List.append t1.extensions' t2.extensions');
+         })
       let to_proto' =
         let spec = Runtime'.Serialize.C.( repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         let serialize = Runtime'.Serialize.serialize spec in
@@ -1495,24 +1397,21 @@ end = struct
       let name' () = "descriptor.google.protobuf.EnumOptions"
       type t = { allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?allow_alias ?(deprecated = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { allow_alias; deprecated; uninterpreted_option; extensions' }
-      let merge = (fun t1 t2 ->
-        let allow_alias = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, bool) ) t1.allow_alias t2.allow_alias in
-
-        let deprecated = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (3, bool, Some (false)) ) t1.deprecated t2.deprecated in
-
-        let uninterpreted_option = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option in
-
-        let extensions' = List.append t1.extensions' t2.extensions' in
-        { allow_alias; deprecated; uninterpreted_option; extensions' })
+      let merge = (fun t1 t2 -> {
+        allow_alias = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, bool) ) t1.allow_alias t2.allow_alias);
+        deprecated = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (3, bool, (false)) ) t1.deprecated t2.deprecated);
+        uninterpreted_option = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option);
+        extensions' = (List.append t1.extensions' t2.extensions');
+         })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Serialize.C.( basic_opt (2, bool) ^:: basic (3, bool, (false)) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { allow_alias; deprecated; uninterpreted_option; extensions' } -> serialize writer allow_alias deprecated uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun allow_alias deprecated uninterpreted_option extensions' -> { allow_alias; deprecated; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic_opt (2, bool) ^:: basic (3, bool, Some (false)) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Deserialize.C.( basic_opt (2, bool) ^:: basic (3, bool, (false)) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1529,22 +1428,20 @@ end = struct
       let name' () = "descriptor.google.protobuf.EnumValueOptions"
       type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(deprecated = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { deprecated; uninterpreted_option; extensions' }
-      let merge = (fun t1 t2 ->
-        let deprecated = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ) t1.deprecated t2.deprecated in
-
-        let uninterpreted_option = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option in
-
-        let extensions' = List.append t1.extensions' t2.extensions' in
-        { deprecated; uninterpreted_option; extensions' })
+      let merge = (fun t1 t2 -> {
+        deprecated = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (1, bool, (false)) ) t1.deprecated t2.deprecated);
+        uninterpreted_option = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option);
+        extensions' = (List.append t1.extensions' t2.extensions');
+         })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic (1, bool, Some (false)) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Serialize.C.( basic (1, bool, (false)) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { deprecated; uninterpreted_option; extensions' } -> serialize writer deprecated uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun deprecated uninterpreted_option extensions' -> { deprecated; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Deserialize.C.( basic (1, bool, (false)) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1561,22 +1458,20 @@ end = struct
       let name' () = "descriptor.google.protobuf.ServiceOptions"
       type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(deprecated = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { deprecated; uninterpreted_option; extensions' }
-      let merge = (fun t1 t2 ->
-        let deprecated = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (33, bool, Some (false)) ) t1.deprecated t2.deprecated in
-
-        let uninterpreted_option = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option in
-
-        let extensions' = List.append t1.extensions' t2.extensions' in
-        { deprecated; uninterpreted_option; extensions' })
+      let merge = (fun t1 t2 -> {
+        deprecated = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (33, bool, (false)) ) t1.deprecated t2.deprecated);
+        uninterpreted_option = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option);
+        extensions' = (List.append t1.extensions' t2.extensions');
+         })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic (33, bool, Some (false)) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Serialize.C.( basic (33, bool, (false)) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { deprecated; uninterpreted_option; extensions' } -> serialize writer deprecated uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun deprecated uninterpreted_option extensions' -> { deprecated; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (33, bool, Some (false)) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Deserialize.C.( basic (33, bool, (false)) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1619,24 +1514,21 @@ end = struct
       let name' () = "descriptor.google.protobuf.MethodOptions"
       type t = { deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
       let make ?(deprecated = false) ?(idempotency_level = IdempotencyLevel.IDEMPOTENCY_UNKNOWN) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { deprecated; idempotency_level; uninterpreted_option; extensions' }
-      let merge = (fun t1 t2 ->
-        let deprecated = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (33, bool, Some (false)) ) t1.deprecated t2.deprecated in
-
-        let idempotency_level = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (34, (enum IdempotencyLevel.from_int_exn), Some (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ) t1.idempotency_level t2.idempotency_level in
-
-        let uninterpreted_option = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option in
-
-        let extensions' = List.append t1.extensions' t2.extensions' in
-        { deprecated; idempotency_level; uninterpreted_option; extensions' })
+      let merge = (fun t1 t2 -> {
+        deprecated = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (33, bool, (false)) ) t1.deprecated t2.deprecated);
+        idempotency_level = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (34, (enum IdempotencyLevel.from_int_exn), (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ) t1.idempotency_level t2.idempotency_level);
+        uninterpreted_option = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ) t1.uninterpreted_option t2.uninterpreted_option);
+        extensions' = (List.append t1.extensions' t2.extensions');
+         })
       let to_proto' =
-        let spec = Runtime'.Serialize.C.( basic (33, bool, Some (false)) ^:: basic (34, (enum IdempotencyLevel.to_int), Some (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Serialize.C.( basic (33, bool, (false)) ^:: basic (34, (enum IdempotencyLevel.to_int), (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ^:: repeated (999, (message UninterpretedOption.to_proto'), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         let serialize = Runtime'.Serialize.serialize spec in
         fun writer { deprecated; idempotency_level; uninterpreted_option; extensions' } -> serialize writer deprecated idempotency_level uninterpreted_option extensions'
 
       let to_proto t = to_proto' (Runtime'.Writer.init ()) t
       let from_proto_exn =
         let constructor = fun deprecated idempotency_level uninterpreted_option extensions' -> { deprecated; idempotency_level; uninterpreted_option; extensions' } in
-        let spec = Runtime'.Deserialize.C.( basic (33, bool, Some (false)) ^:: basic (34, (enum IdempotencyLevel.from_int_exn), Some (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
+        let spec = Runtime'.Deserialize.C.( basic (33, bool, (false)) ^:: basic (34, (enum IdempotencyLevel.from_int_exn), (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ^:: repeated (999, (message ((fun writer -> UninterpretedOption.from_proto_exn writer), UninterpretedOption.merge)), not_packed) ^:: nil_ext [ (1000, 536870912) ] ) in
         Runtime'.Deserialize.deserialize spec constructor
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     end
@@ -1673,43 +1565,34 @@ end = struct
         let name' () = "descriptor.google.protobuf.UninterpretedOption.NamePart"
         type t = { name_part: string; is_extension: bool }
         let make ~name_part ~is_extension () = { name_part; is_extension }
-        let merge = (fun t1 t2 ->
-          let name_part = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (1, string, None) ) t1.name_part t2.name_part in
-
-          let is_extension = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (2, bool, None) ) t1.is_extension t2.is_extension in
-
-          { name_part; is_extension })
+        let merge = (fun t1 t2 -> {
+          name_part = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_req (1, string) ) t1.name_part t2.name_part);
+          is_extension = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_req (2, bool) ) t1.is_extension t2.is_extension);
+           })
         let to_proto' =
-          let spec = Runtime'.Serialize.C.( basic (1, string, None) ^:: basic (2, bool, None) ^:: nil ) in
+          let spec = Runtime'.Serialize.C.( basic_req (1, string) ^:: basic_req (2, bool) ^:: nil ) in
           let serialize = Runtime'.Serialize.serialize spec in
           fun writer { name_part; is_extension } -> serialize writer name_part is_extension
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
         let from_proto_exn =
           let constructor = fun name_part is_extension -> { name_part; is_extension } in
-          let spec = Runtime'.Deserialize.C.( basic (1, string, None) ^:: basic (2, bool, None) ^:: nil ) in
+          let spec = Runtime'.Deserialize.C.( basic_req (1, string) ^:: basic_req (2, bool) ^:: nil ) in
           Runtime'.Deserialize.deserialize spec constructor
         let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       let name' () = "descriptor.google.protobuf.UninterpretedOption"
       type t = { name: NamePart.t list; identifier_value: string option; positive_int_value: int option; negative_int_value: int option; double_value: float option; string_value: bytes option; aggregate_value: string option }
       let make ?(name = []) ?identifier_value ?positive_int_value ?negative_int_value ?double_value ?string_value ?aggregate_value () = { name; identifier_value; positive_int_value; negative_int_value; double_value; string_value; aggregate_value }
-      let merge = (fun t1 t2 ->
-        let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (2, (message ((fun writer -> NamePart.from_proto_exn writer), NamePart.merge)), not_packed) ) t1.name t2.name in
-
-        let identifier_value = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, string) ) t1.identifier_value t2.identifier_value in
-
-        let positive_int_value = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (4, uint64_int) ) t1.positive_int_value t2.positive_int_value in
-
-        let negative_int_value = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (5, int64_int) ) t1.negative_int_value t2.negative_int_value in
-
-        let double_value = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (6, double) ) t1.double_value t2.double_value in
-
-        let string_value = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (7, bytes) ) t1.string_value t2.string_value in
-
-        let aggregate_value = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (8, string) ) t1.aggregate_value t2.aggregate_value in
-
-        { name; identifier_value; positive_int_value; negative_int_value; double_value; string_value; aggregate_value })
+      let merge = (fun t1 t2 -> {
+        name = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (2, (message ((fun writer -> NamePart.from_proto_exn writer), NamePart.merge)), not_packed) ) t1.name t2.name);
+        identifier_value = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, string) ) t1.identifier_value t2.identifier_value);
+        positive_int_value = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (4, uint64_int) ) t1.positive_int_value t2.positive_int_value);
+        negative_int_value = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (5, int64_int) ) t1.negative_int_value t2.negative_int_value);
+        double_value = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (6, double) ) t1.double_value t2.double_value);
+        string_value = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (7, bytes) ) t1.string_value t2.string_value);
+        aggregate_value = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (8, string) ) t1.aggregate_value t2.aggregate_value);
+         })
       let to_proto' =
         let spec = Runtime'.Serialize.C.( repeated (2, (message NamePart.to_proto'), not_packed) ^:: basic_opt (3, string) ^:: basic_opt (4, uint64_int) ^:: basic_opt (5, int64_int) ^:: basic_opt (6, double) ^:: basic_opt (7, bytes) ^:: basic_opt (8, string) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
@@ -1755,18 +1638,13 @@ end = struct
         let name' () = "descriptor.google.protobuf.SourceCodeInfo.Location"
         type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
         let make ?(path = []) ?(span = []) ?leading_comments ?trailing_comments ?(leading_detached_comments = []) () = { path; span; leading_comments; trailing_comments; leading_detached_comments }
-        let merge = (fun t1 t2 ->
-          let path = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (1, int32_int, packed) ) t1.path t2.path in
-
-          let span = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (2, int32_int, packed) ) t1.span t2.span in
-
-          let leading_comments = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, string) ) t1.leading_comments t2.leading_comments in
-
-          let trailing_comments = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (4, string) ) t1.trailing_comments t2.trailing_comments in
-
-          let leading_detached_comments = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (6, string, not_packed) ) t1.leading_detached_comments t2.leading_detached_comments in
-
-          { path; span; leading_comments; trailing_comments; leading_detached_comments })
+        let merge = (fun t1 t2 -> {
+          path = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (1, int32_int, packed) ) t1.path t2.path);
+          span = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (2, int32_int, packed) ) t1.span t2.span);
+          leading_comments = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, string) ) t1.leading_comments t2.leading_comments);
+          trailing_comments = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (4, string) ) t1.trailing_comments t2.trailing_comments);
+          leading_detached_comments = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (6, string, not_packed) ) t1.leading_detached_comments t2.leading_detached_comments);
+           })
         let to_proto' =
           let spec = Runtime'.Serialize.C.( repeated (1, int32_int, packed) ^:: repeated (2, int32_int, packed) ^:: basic_opt (3, string) ^:: basic_opt (4, string) ^:: repeated (6, string, not_packed) ^:: nil ) in
           let serialize = Runtime'.Serialize.serialize spec in
@@ -1782,10 +1660,7 @@ end = struct
       let name' () = "descriptor.google.protobuf.SourceCodeInfo"
       type t = (Location.t list)
       let make ?(location = []) () = (location)
-      let merge = (fun (t1_location) (t2_location) ->
-        let location = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (1, (message ((fun writer -> Location.from_proto_exn writer), Location.merge)), not_packed) ) t1_location t2_location in
-
-        (location))
+      let merge = (fun (t1_location) (t2_location) -> (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (1, (message ((fun writer -> Location.from_proto_exn writer), Location.merge)), not_packed) ) t1_location t2_location))
       let to_proto' =
         let spec = Runtime'.Serialize.C.( repeated (1, (message Location.to_proto'), not_packed) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in
@@ -1831,16 +1706,12 @@ end = struct
         let name' () = "descriptor.google.protobuf.GeneratedCodeInfo.Annotation"
         type t = { path: int list; source_file: string option; begin': int option; end': int option }
         let make ?(path = []) ?source_file ?begin' ?end' () = { path; source_file; begin'; end' }
-        let merge = (fun t1 t2 ->
-          let path = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (1, int32_int, packed) ) t1.path t2.path in
-
-          let source_file = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, string) ) t1.source_file t2.source_file in
-
-          let begin' = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, int32_int) ) t1.begin' t2.begin' in
-
-          let end' = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (4, int32_int) ) t1.end' t2.end' in
-
-          { path; source_file; begin'; end' })
+        let merge = (fun t1 t2 -> {
+          path = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (1, int32_int, packed) ) t1.path t2.path);
+          source_file = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, string) ) t1.source_file t2.source_file);
+          begin' = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, int32_int) ) t1.begin' t2.begin');
+          end' = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (4, int32_int) ) t1.end' t2.end');
+           })
         let to_proto' =
           let spec = Runtime'.Serialize.C.( repeated (1, int32_int, packed) ^:: basic_opt (2, string) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, int32_int) ^:: nil ) in
           let serialize = Runtime'.Serialize.serialize spec in
@@ -1856,10 +1727,7 @@ end = struct
       let name' () = "descriptor.google.protobuf.GeneratedCodeInfo"
       type t = (Annotation.t list)
       let make ?(annotation = []) () = (annotation)
-      let merge = (fun (t1_annotation) (t2_annotation) ->
-        let annotation = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (1, (message ((fun writer -> Annotation.from_proto_exn writer), Annotation.merge)), not_packed) ) t1_annotation t2_annotation in
-
-        (annotation))
+      let merge = (fun (t1_annotation) (t2_annotation) -> (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (1, (message ((fun writer -> Annotation.from_proto_exn writer), Annotation.merge)), not_packed) ) t1_annotation t2_annotation))
       let to_proto' =
         let spec = Runtime'.Serialize.C.( repeated (1, (message Annotation.to_proto'), not_packed) ^:: nil ) in
         let serialize = Runtime'.Serialize.serialize spec in

--- a/src/spec/options.ml
+++ b/src/spec/options.ml
@@ -25,16 +25,21 @@ end
 (**/**)
 module rec Options : sig
   val name': unit -> string
-  type t = bool
+  type t = (bool)
   val make: ?mangle_names:bool -> unit -> t
+  val merge: t -> t -> t
   val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
   val to_proto: t -> Runtime'.Writer.t
   val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
   val from_proto_exn: Runtime'.Reader.t -> t
 end = struct
   let name' () = "options.Options"
-  type t = bool
-  let make ?(mangle_names = false) () = mangle_names
+  type t = (bool)
+  let make ?(mangle_names = false) () = (mangle_names)
+  let merge = (fun (t1_mangle_names) (t2_mangle_names) ->
+    let mangle_names = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ) t1_mangle_names t2_mangle_names in
+
+    (mangle_names))
   let to_proto' =
     let spec = Runtime'.Serialize.C.( basic (1, bool, Some (false)) ^:: nil ) in
     let serialize = Runtime'.Serialize.serialize spec in
@@ -42,7 +47,7 @@ end = struct
 
   let to_proto t = to_proto' (Runtime'.Writer.init ()) t
   let from_proto_exn =
-    let constructor = fun mangle_names -> mangle_names in
+    let constructor = fun mangle_names -> (mangle_names) in
     let spec = Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ^:: nil ) in
     Runtime'.Deserialize.deserialize spec constructor
   let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
@@ -54,10 +59,10 @@ and Ocaml_options : sig
   val set: Imported'modules.Descriptor.Google.Protobuf.FileOptions.t -> Options.t option -> Imported'modules.Descriptor.Google.Protobuf.FileOptions.t
 end = struct
   type t = Options.t option
-  let get_exn extendee = Runtime'.Extensions.get Runtime'.Deserialize.C.(basic_opt (1074, (message (fun t -> Options.from_proto_exn t)))) (extendee.Imported'modules.Descriptor.Google.Protobuf.FileOptions.extensions')
+  let get_exn extendee = Runtime'.Extensions.get Runtime'.Deserialize.C.(basic_opt (1074, (message ((fun writer -> Options.from_proto_exn writer), Options.merge)))) (extendee.Imported'modules.Descriptor.Google.Protobuf.FileOptions.extensions')
   let get extendee = Runtime'.Result.catch (fun () -> get_exn extendee)
   let set extendee t =
-    let extensions' = Runtime'.Extensions.set Runtime'.Serialize.C.(basic_opt (1074, (message (fun t -> Options.to_proto' t)))) (extendee.Imported'modules.Descriptor.Google.Protobuf.FileOptions.extensions') t in
+    let extensions' = Runtime'.Extensions.set Runtime'.Serialize.C.(basic_opt (1074, (message Options.to_proto'))) (extendee.Imported'modules.Descriptor.Google.Protobuf.FileOptions.extensions') t in
     { extendee with Imported'modules.Descriptor.Google.Protobuf.FileOptions.extensions' = extensions' } [@@warning "-23"]
 
 end

--- a/src/spec/options.ml
+++ b/src/spec/options.ml
@@ -36,19 +36,16 @@ end = struct
   let name' () = "options.Options"
   type t = (bool)
   let make ?(mangle_names = false) () = (mangle_names)
-  let merge = (fun (t1_mangle_names) (t2_mangle_names) ->
-    let mangle_names = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ) t1_mangle_names t2_mangle_names in
-
-    (mangle_names))
+  let merge = (fun (t1_mangle_names) (t2_mangle_names) -> (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic (1, bool, (false)) ) t1_mangle_names t2_mangle_names))
   let to_proto' =
-    let spec = Runtime'.Serialize.C.( basic (1, bool, Some (false)) ^:: nil ) in
+    let spec = Runtime'.Serialize.C.( basic (1, bool, (false)) ^:: nil ) in
     let serialize = Runtime'.Serialize.serialize spec in
     serialize
 
   let to_proto t = to_proto' (Runtime'.Writer.init ()) t
   let from_proto_exn =
     let constructor = fun mangle_names -> (mangle_names) in
-    let spec = Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ^:: nil ) in
+    let spec = Runtime'.Deserialize.C.( basic (1, bool, (false)) ^:: nil ) in
     Runtime'.Deserialize.deserialize spec constructor
   let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
 end

--- a/src/spec/options.ml
+++ b/src/spec/options.ml
@@ -26,7 +26,7 @@ end
 module rec Options : sig
   val name': unit -> string
   type t = bool
-  val make : ?mangle_names:bool -> unit -> t
+  val make: ?mangle_names:bool -> unit -> t
   val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
   val to_proto: t -> Runtime'.Writer.t
   val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -36,20 +36,16 @@ end = struct
   type t = bool
   let make ?(mangle_names = false) () = mangle_names
   let to_proto' =
-    let apply = fun ~f:f' writer mangle_names -> f' [] writer mangle_names in
     let spec = Runtime'.Serialize.C.( basic (1, bool, Some (false)) ^:: nil ) in
-    let serialize = Runtime'.Serialize.serialize [] spec in
-    fun writer t -> apply ~f:serialize writer t
+    let serialize = Runtime'.Serialize.serialize spec in
+    serialize
 
   let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
   let from_proto_exn =
-    let constructor = fun mangle_names _extensions -> mangle_names in
+    let constructor = fun mangle_names -> mangle_names in
     let spec = Runtime'.Deserialize.C.( basic (1, bool, Some (false)) ^:: nil ) in
-    let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-    fun writer -> deserialize writer
-    let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+    Runtime'.Deserialize.deserialize spec constructor
+  let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
 end
 and Ocaml_options : sig
   type t = Options.t option
@@ -62,6 +58,6 @@ end = struct
   let get extendee = Runtime'.Result.catch (fun () -> get_exn extendee)
   let set extendee t =
     let extensions' = Runtime'.Extensions.set Runtime'.Serialize.C.(basic_opt (1074, (message (fun t -> Options.to_proto' t)))) (extendee.Imported'modules.Descriptor.Google.Protobuf.FileOptions.extensions') t in
-    { extendee with Imported'modules.Descriptor.Google.Protobuf.FileOptions.extensions' = extensions' }
+    { extendee with Imported'modules.Descriptor.Google.Protobuf.FileOptions.extensions' = extensions' } [@@warning "-23"]
 
 end

--- a/src/spec/plugin.ml
+++ b/src/spec/plugin.ml
@@ -29,7 +29,7 @@ module rec Google : sig
       module rec Version : sig
         val name': unit -> string
         type t = { major: int option; minor: int option; patch: int option; suffix: string option }
-        val make : ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
+        val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -38,7 +38,7 @@ module rec Google : sig
       and CodeGeneratorRequest : sig
         val name': unit -> string
         type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
-        val make : ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
+        val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -54,7 +54,7 @@ module rec Google : sig
         and File : sig
           val name': unit -> string
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
-          val make : ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
+          val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
           val to_proto: t -> Runtime'.Writer.t
           val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -62,7 +62,7 @@ module rec Google : sig
         end
         val name': unit -> string
         type t = { error: string option; supported_features: int option; file: File.t list }
-        val make : ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
+        val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -76,7 +76,7 @@ end = struct
       module rec Version : sig
         val name': unit -> string
         type t = { major: int option; minor: int option; patch: int option; suffix: string option }
-        val make : ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
+        val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -85,7 +85,7 @@ end = struct
       and CodeGeneratorRequest : sig
         val name': unit -> string
         type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
-        val make : ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
+        val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -101,7 +101,7 @@ end = struct
         and File : sig
           val name': unit -> string
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
-          val make : ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
+          val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
           val to_proto: t -> Runtime'.Writer.t
           val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -109,7 +109,7 @@ end = struct
         end
         val name': unit -> string
         type t = { error: string option; supported_features: int option; file: File.t list }
-        val make : ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
+        val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -121,7 +121,7 @@ end = struct
       module rec Version : sig
         val name': unit -> string
         type t = { major: int option; minor: int option; patch: int option; suffix: string option }
-        val make : ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
+        val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -130,7 +130,7 @@ end = struct
       and CodeGeneratorRequest : sig
         val name': unit -> string
         type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
-        val make : ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
+        val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -146,7 +146,7 @@ end = struct
         and File : sig
           val name': unit -> string
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
-          val make : ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
+          val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
           val to_proto: t -> Runtime'.Writer.t
           val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -154,7 +154,7 @@ end = struct
         end
         val name': unit -> string
         type t = { error: string option; supported_features: int option; file: File.t list }
-        val make : ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
+        val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -164,7 +164,7 @@ end = struct
       module rec Version : sig
         val name': unit -> string
         type t = { major: int option; minor: int option; patch: int option; suffix: string option }
-        val make : ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
+        val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -174,25 +174,21 @@ end = struct
         type t = { major: int option; minor: int option; patch: int option; suffix: string option }
         let make ?major ?minor ?patch ?suffix () = { major; minor; patch; suffix }
         let to_proto' =
-          let apply = fun ~f:f' writer { major; minor; patch; suffix } -> f' [] writer major minor patch suffix in
           let spec = Runtime'.Serialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, string) ^:: nil ) in
-          let serialize = Runtime'.Serialize.serialize [] spec in
-          fun writer t -> apply ~f:serialize writer t
+          let serialize = Runtime'.Serialize.serialize spec in
+          fun writer { major; minor; patch; suffix } -> serialize writer major minor patch suffix
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
         let from_proto_exn =
-          let constructor = fun major minor patch suffix _extensions -> { major; minor; patch; suffix } in
+          let constructor = fun major minor patch suffix -> { major; minor; patch; suffix } in
           let spec = Runtime'.Deserialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, string) ^:: nil ) in
-          let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-          fun writer -> deserialize writer
-          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+          Runtime'.Deserialize.deserialize spec constructor
+        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       and CodeGeneratorRequest : sig
         val name': unit -> string
         type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
-        val make : ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
+        val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -202,20 +198,16 @@ end = struct
         type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
         let make ?(file_to_generate = []) ?parameter ?compiler_version ?(proto_file = []) () = { file_to_generate; parameter; compiler_version; proto_file }
         let to_proto' =
-          let apply = fun ~f:f' writer { file_to_generate; parameter; compiler_version; proto_file } -> f' [] writer file_to_generate parameter compiler_version proto_file in
           let spec = Runtime'.Serialize.C.( repeated (1, string, not_packed) ^:: basic_opt (2, string) ^:: basic_opt (3, (message (fun t -> Version.to_proto' t))) ^:: repeated (15, (message (fun t -> Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.to_proto' t)), not_packed) ^:: nil ) in
-          let serialize = Runtime'.Serialize.serialize [] spec in
-          fun writer t -> apply ~f:serialize writer t
+          let serialize = Runtime'.Serialize.serialize spec in
+          fun writer { file_to_generate; parameter; compiler_version; proto_file } -> serialize writer file_to_generate parameter compiler_version proto_file
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
         let from_proto_exn =
-          let constructor = fun file_to_generate parameter compiler_version proto_file _extensions -> { file_to_generate; parameter; compiler_version; proto_file } in
+          let constructor = fun file_to_generate parameter compiler_version proto_file -> { file_to_generate; parameter; compiler_version; proto_file } in
           let spec = Runtime'.Deserialize.C.( repeated (1, string, not_packed) ^:: basic_opt (2, string) ^:: basic_opt (3, (message (fun t -> Version.from_proto_exn t))) ^:: repeated (15, (message (fun t -> Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.from_proto_exn t)), not_packed) ^:: nil ) in
-          let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-          fun writer -> deserialize writer
-          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+          Runtime'.Deserialize.deserialize spec constructor
+        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
       and CodeGeneratorResponse : sig
         module rec Feature : sig
@@ -227,7 +219,7 @@ end = struct
         and File : sig
           val name': unit -> string
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
-          val make : ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
+          val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
           val to_proto: t -> Runtime'.Writer.t
           val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -235,7 +227,7 @@ end = struct
         end
         val name': unit -> string
         type t = { error: string option; supported_features: int option; file: File.t list }
-        val make : ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
+        val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -262,7 +254,7 @@ end = struct
         and File : sig
           val name': unit -> string
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
-          val make : ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
+          val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
           val to_proto: t -> Runtime'.Writer.t
           val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -272,39 +264,31 @@ end = struct
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
           let make ?name ?insertion_point ?content ?generated_code_info () = { name; insertion_point; content; generated_code_info }
           let to_proto' =
-            let apply = fun ~f:f' writer { name; insertion_point; content; generated_code_info } -> f' [] writer name insertion_point content generated_code_info in
             let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (15, string) ^:: basic_opt (16, (message (fun t -> Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.to_proto' t))) ^:: nil ) in
-            let serialize = Runtime'.Serialize.serialize [] spec in
-            fun writer t -> apply ~f:serialize writer t
+            let serialize = Runtime'.Serialize.serialize spec in
+            fun writer { name; insertion_point; content; generated_code_info } -> serialize writer name insertion_point content generated_code_info
 
           let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
           let from_proto_exn =
-            let constructor = fun name insertion_point content generated_code_info _extensions -> { name; insertion_point; content; generated_code_info } in
+            let constructor = fun name insertion_point content generated_code_info -> { name; insertion_point; content; generated_code_info } in
             let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (15, string) ^:: basic_opt (16, (message (fun t -> Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.from_proto_exn t))) ^:: nil ) in
-            let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-            fun writer -> deserialize writer
-            let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+            Runtime'.Deserialize.deserialize spec constructor
+          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
         end
         let name' () = "plugin.google.protobuf.compiler.CodeGeneratorResponse"
         type t = { error: string option; supported_features: int option; file: File.t list }
         let make ?error ?supported_features ?(file = []) () = { error; supported_features; file }
         let to_proto' =
-          let apply = fun ~f:f' writer { error; supported_features; file } -> f' [] writer error supported_features file in
           let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, uint64_int) ^:: repeated (15, (message (fun t -> File.to_proto' t)), not_packed) ^:: nil ) in
-          let serialize = Runtime'.Serialize.serialize [] spec in
-          fun writer t -> apply ~f:serialize writer t
+          let serialize = Runtime'.Serialize.serialize spec in
+          fun writer { error; supported_features; file } -> serialize writer error supported_features file
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
-
         let from_proto_exn =
-          let constructor = fun error supported_features file _extensions -> { error; supported_features; file } in
+          let constructor = fun error supported_features file -> { error; supported_features; file } in
           let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, uint64_int) ^:: repeated (15, (message (fun t -> File.from_proto_exn t)), not_packed) ^:: nil ) in
-          let deserialize = Runtime'.Deserialize.deserialize [] spec constructor in
-          fun writer -> deserialize writer
-          let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
-
+          Runtime'.Deserialize.deserialize spec constructor
+        let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
     end
   end

--- a/src/spec/plugin.ml
+++ b/src/spec/plugin.ml
@@ -30,6 +30,7 @@ module rec Google : sig
         val name': unit -> string
         type t = { major: int option; minor: int option; patch: int option; suffix: string option }
         val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -39,6 +40,7 @@ module rec Google : sig
         val name': unit -> string
         type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
         val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -55,6 +57,7 @@ module rec Google : sig
           val name': unit -> string
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
           val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
+          val merge: t -> t -> t
           val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
           val to_proto: t -> Runtime'.Writer.t
           val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -63,6 +66,7 @@ module rec Google : sig
         val name': unit -> string
         type t = { error: string option; supported_features: int option; file: File.t list }
         val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -77,6 +81,7 @@ end = struct
         val name': unit -> string
         type t = { major: int option; minor: int option; patch: int option; suffix: string option }
         val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -86,6 +91,7 @@ end = struct
         val name': unit -> string
         type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
         val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -102,6 +108,7 @@ end = struct
           val name': unit -> string
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
           val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
+          val merge: t -> t -> t
           val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
           val to_proto: t -> Runtime'.Writer.t
           val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -110,6 +117,7 @@ end = struct
         val name': unit -> string
         type t = { error: string option; supported_features: int option; file: File.t list }
         val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -122,6 +130,7 @@ end = struct
         val name': unit -> string
         type t = { major: int option; minor: int option; patch: int option; suffix: string option }
         val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -131,6 +140,7 @@ end = struct
         val name': unit -> string
         type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
         val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -147,6 +157,7 @@ end = struct
           val name': unit -> string
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
           val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
+          val merge: t -> t -> t
           val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
           val to_proto: t -> Runtime'.Writer.t
           val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -155,6 +166,7 @@ end = struct
         val name': unit -> string
         type t = { error: string option; supported_features: int option; file: File.t list }
         val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -165,6 +177,7 @@ end = struct
         val name': unit -> string
         type t = { major: int option; minor: int option; patch: int option; suffix: string option }
         val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -173,6 +186,16 @@ end = struct
         let name' () = "plugin.google.protobuf.compiler.Version"
         type t = { major: int option; minor: int option; patch: int option; suffix: string option }
         let make ?major ?minor ?patch ?suffix () = { major; minor; patch; suffix }
+        let merge = (fun t1 t2 ->
+          let major = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, int32_int) ) t1.major t2.major in
+
+          let minor = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, int32_int) ) t1.minor t2.minor in
+
+          let patch = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, int32_int) ) t1.patch t2.patch in
+
+          let suffix = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (4, string) ) t1.suffix t2.suffix in
+
+          { major; minor; patch; suffix })
         let to_proto' =
           let spec = Runtime'.Serialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, string) ^:: nil ) in
           let serialize = Runtime'.Serialize.serialize spec in
@@ -189,6 +212,7 @@ end = struct
         val name': unit -> string
         type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
         val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -197,15 +221,25 @@ end = struct
         let name' () = "plugin.google.protobuf.compiler.CodeGeneratorRequest"
         type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
         let make ?(file_to_generate = []) ?parameter ?compiler_version ?(proto_file = []) () = { file_to_generate; parameter; compiler_version; proto_file }
+        let merge = (fun t1 t2 ->
+          let file_to_generate = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (1, string, not_packed) ) t1.file_to_generate t2.file_to_generate in
+
+          let parameter = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, string) ) t1.parameter t2.parameter in
+
+          let compiler_version = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, (message ((fun writer -> Version.from_proto_exn writer), Version.merge))) ) t1.compiler_version t2.compiler_version in
+
+          let proto_file = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (15, (message ((fun writer -> Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.from_proto_exn writer), Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.merge)), not_packed) ) t1.proto_file t2.proto_file in
+
+          { file_to_generate; parameter; compiler_version; proto_file })
         let to_proto' =
-          let spec = Runtime'.Serialize.C.( repeated (1, string, not_packed) ^:: basic_opt (2, string) ^:: basic_opt (3, (message (fun t -> Version.to_proto' t))) ^:: repeated (15, (message (fun t -> Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.to_proto' t)), not_packed) ^:: nil ) in
+          let spec = Runtime'.Serialize.C.( repeated (1, string, not_packed) ^:: basic_opt (2, string) ^:: basic_opt (3, (message Version.to_proto')) ^:: repeated (15, (message Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.to_proto'), not_packed) ^:: nil ) in
           let serialize = Runtime'.Serialize.serialize spec in
           fun writer { file_to_generate; parameter; compiler_version; proto_file } -> serialize writer file_to_generate parameter compiler_version proto_file
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
         let from_proto_exn =
           let constructor = fun file_to_generate parameter compiler_version proto_file -> { file_to_generate; parameter; compiler_version; proto_file } in
-          let spec = Runtime'.Deserialize.C.( repeated (1, string, not_packed) ^:: basic_opt (2, string) ^:: basic_opt (3, (message (fun t -> Version.from_proto_exn t))) ^:: repeated (15, (message (fun t -> Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.from_proto_exn t)), not_packed) ^:: nil ) in
+          let spec = Runtime'.Deserialize.C.( repeated (1, string, not_packed) ^:: basic_opt (2, string) ^:: basic_opt (3, (message ((fun writer -> Version.from_proto_exn writer), Version.merge))) ^:: repeated (15, (message ((fun writer -> Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.from_proto_exn writer), Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.merge)), not_packed) ^:: nil ) in
           Runtime'.Deserialize.deserialize spec constructor
         let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end
@@ -220,6 +254,7 @@ end = struct
           val name': unit -> string
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
           val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
+          val merge: t -> t -> t
           val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
           val to_proto: t -> Runtime'.Writer.t
           val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -228,6 +263,7 @@ end = struct
         val name': unit -> string
         type t = { error: string option; supported_features: int option; file: File.t list }
         val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
+        val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
         val to_proto: t -> Runtime'.Writer.t
         val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -255,6 +291,7 @@ end = struct
           val name': unit -> string
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
           val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
+          val merge: t -> t -> t
           val to_proto': Runtime'.Writer.t -> t -> Runtime'.Writer.t
           val to_proto: t -> Runtime'.Writer.t
           val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
@@ -263,30 +300,48 @@ end = struct
           let name' () = "plugin.google.protobuf.compiler.CodeGeneratorResponse.File"
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
           let make ?name ?insertion_point ?content ?generated_code_info () = { name; insertion_point; content; generated_code_info }
+          let merge = (fun t1 t2 ->
+            let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name in
+
+            let insertion_point = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, string) ) t1.insertion_point t2.insertion_point in
+
+            let content = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (15, string) ) t1.content t2.content in
+
+            let generated_code_info = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (16, (message ((fun writer -> Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.from_proto_exn writer), Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.merge))) ) t1.generated_code_info t2.generated_code_info in
+
+            { name; insertion_point; content; generated_code_info })
           let to_proto' =
-            let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (15, string) ^:: basic_opt (16, (message (fun t -> Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.to_proto' t))) ^:: nil ) in
+            let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (15, string) ^:: basic_opt (16, (message Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.to_proto')) ^:: nil ) in
             let serialize = Runtime'.Serialize.serialize spec in
             fun writer { name; insertion_point; content; generated_code_info } -> serialize writer name insertion_point content generated_code_info
 
           let to_proto t = to_proto' (Runtime'.Writer.init ()) t
           let from_proto_exn =
             let constructor = fun name insertion_point content generated_code_info -> { name; insertion_point; content; generated_code_info } in
-            let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (15, string) ^:: basic_opt (16, (message (fun t -> Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.from_proto_exn t))) ^:: nil ) in
+            let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (15, string) ^:: basic_opt (16, (message ((fun writer -> Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.from_proto_exn writer), Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.merge))) ^:: nil ) in
             Runtime'.Deserialize.deserialize spec constructor
           let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
         end
         let name' () = "plugin.google.protobuf.compiler.CodeGeneratorResponse"
         type t = { error: string option; supported_features: int option; file: File.t list }
         let make ?error ?supported_features ?(file = []) () = { error; supported_features; file }
+        let merge = (fun t1 t2 ->
+          let error = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.error t2.error in
+
+          let supported_features = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, uint64_int) ) t1.supported_features t2.supported_features in
+
+          let file = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (15, (message ((fun writer -> File.from_proto_exn writer), File.merge)), not_packed) ) t1.file t2.file in
+
+          { error; supported_features; file })
         let to_proto' =
-          let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, uint64_int) ^:: repeated (15, (message (fun t -> File.to_proto' t)), not_packed) ^:: nil ) in
+          let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, uint64_int) ^:: repeated (15, (message File.to_proto'), not_packed) ^:: nil ) in
           let serialize = Runtime'.Serialize.serialize spec in
           fun writer { error; supported_features; file } -> serialize writer error supported_features file
 
         let to_proto t = to_proto' (Runtime'.Writer.init ()) t
         let from_proto_exn =
           let constructor = fun error supported_features file -> { error; supported_features; file } in
-          let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, uint64_int) ^:: repeated (15, (message (fun t -> File.from_proto_exn t)), not_packed) ^:: nil ) in
+          let spec = Runtime'.Deserialize.C.( basic_opt (1, string) ^:: basic_opt (2, uint64_int) ^:: repeated (15, (message ((fun writer -> File.from_proto_exn writer), File.merge)), not_packed) ^:: nil ) in
           Runtime'.Deserialize.deserialize spec constructor
         let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       end

--- a/src/spec/plugin.ml
+++ b/src/spec/plugin.ml
@@ -186,16 +186,12 @@ end = struct
         let name' () = "plugin.google.protobuf.compiler.Version"
         type t = { major: int option; minor: int option; patch: int option; suffix: string option }
         let make ?major ?minor ?patch ?suffix () = { major; minor; patch; suffix }
-        let merge = (fun t1 t2 ->
-          let major = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, int32_int) ) t1.major t2.major in
-
-          let minor = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, int32_int) ) t1.minor t2.minor in
-
-          let patch = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, int32_int) ) t1.patch t2.patch in
-
-          let suffix = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (4, string) ) t1.suffix t2.suffix in
-
-          { major; minor; patch; suffix })
+        let merge = (fun t1 t2 -> {
+          major = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, int32_int) ) t1.major t2.major);
+          minor = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, int32_int) ) t1.minor t2.minor);
+          patch = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, int32_int) ) t1.patch t2.patch);
+          suffix = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (4, string) ) t1.suffix t2.suffix);
+           })
         let to_proto' =
           let spec = Runtime'.Serialize.C.( basic_opt (1, int32_int) ^:: basic_opt (2, int32_int) ^:: basic_opt (3, int32_int) ^:: basic_opt (4, string) ^:: nil ) in
           let serialize = Runtime'.Serialize.serialize spec in
@@ -221,16 +217,12 @@ end = struct
         let name' () = "plugin.google.protobuf.compiler.CodeGeneratorRequest"
         type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
         let make ?(file_to_generate = []) ?parameter ?compiler_version ?(proto_file = []) () = { file_to_generate; parameter; compiler_version; proto_file }
-        let merge = (fun t1 t2 ->
-          let file_to_generate = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (1, string, not_packed) ) t1.file_to_generate t2.file_to_generate in
-
-          let parameter = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, string) ) t1.parameter t2.parameter in
-
-          let compiler_version = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, (message ((fun writer -> Version.from_proto_exn writer), Version.merge))) ) t1.compiler_version t2.compiler_version in
-
-          let proto_file = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (15, (message ((fun writer -> Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.from_proto_exn writer), Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.merge)), not_packed) ) t1.proto_file t2.proto_file in
-
-          { file_to_generate; parameter; compiler_version; proto_file })
+        let merge = (fun t1 t2 -> {
+          file_to_generate = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (1, string, not_packed) ) t1.file_to_generate t2.file_to_generate);
+          parameter = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, string) ) t1.parameter t2.parameter);
+          compiler_version = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (3, (message ((fun writer -> Version.from_proto_exn writer), Version.merge))) ) t1.compiler_version t2.compiler_version);
+          proto_file = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (15, (message ((fun writer -> Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.from_proto_exn writer), Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.merge)), not_packed) ) t1.proto_file t2.proto_file);
+           })
         let to_proto' =
           let spec = Runtime'.Serialize.C.( repeated (1, string, not_packed) ^:: basic_opt (2, string) ^:: basic_opt (3, (message Version.to_proto')) ^:: repeated (15, (message Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.to_proto'), not_packed) ^:: nil ) in
           let serialize = Runtime'.Serialize.serialize spec in
@@ -300,16 +292,12 @@ end = struct
           let name' () = "plugin.google.protobuf.compiler.CodeGeneratorResponse.File"
           type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
           let make ?name ?insertion_point ?content ?generated_code_info () = { name; insertion_point; content; generated_code_info }
-          let merge = (fun t1 t2 ->
-            let name = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name in
-
-            let insertion_point = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, string) ) t1.insertion_point t2.insertion_point in
-
-            let content = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (15, string) ) t1.content t2.content in
-
-            let generated_code_info = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (16, (message ((fun writer -> Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.from_proto_exn writer), Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.merge))) ) t1.generated_code_info t2.generated_code_info in
-
-            { name; insertion_point; content; generated_code_info })
+          let merge = (fun t1 t2 -> {
+            name = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.name t2.name);
+            insertion_point = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, string) ) t1.insertion_point t2.insertion_point);
+            content = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (15, string) ) t1.content t2.content);
+            generated_code_info = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (16, (message ((fun writer -> Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.from_proto_exn writer), Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.merge))) ) t1.generated_code_info t2.generated_code_info);
+             })
           let to_proto' =
             let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, string) ^:: basic_opt (15, string) ^:: basic_opt (16, (message Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.to_proto')) ^:: nil ) in
             let serialize = Runtime'.Serialize.serialize spec in
@@ -325,14 +313,11 @@ end = struct
         let name' () = "plugin.google.protobuf.compiler.CodeGeneratorResponse"
         type t = { error: string option; supported_features: int option; file: File.t list }
         let make ?error ?supported_features ?(file = []) () = { error; supported_features; file }
-        let merge = (fun t1 t2 ->
-          let error = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.error t2.error in
-
-          let supported_features = Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, uint64_int) ) t1.supported_features t2.supported_features in
-
-          let file = Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (15, (message ((fun writer -> File.from_proto_exn writer), File.merge)), not_packed) ) t1.file t2.file in
-
-          { error; supported_features; file })
+        let merge = (fun t1 t2 -> {
+          error = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (1, string) ) t1.error t2.error);
+          supported_features = (Runtime'.Merge.merge Runtime'.Deserialize.C.( basic_opt (2, uint64_int) ) t1.supported_features t2.supported_features);
+          file = (Runtime'.Merge.merge Runtime'.Deserialize.C.( repeated (15, (message ((fun writer -> File.from_proto_exn writer), File.merge)), not_packed) ) t1.file t2.file);
+           })
         let to_proto' =
           let spec = Runtime'.Serialize.C.( basic_opt (1, string) ^:: basic_opt (2, uint64_int) ^:: repeated (15, (message File.to_proto'), not_packed) ^:: nil ) in
           let serialize = Runtime'.Serialize.serialize spec in

--- a/test/dune
+++ b/test/dune
@@ -35,7 +35,7 @@
 
 (rule
  (targets
-   basic.ml primitive_types.ml int_types.ml repeated.ml enum.ml
+   basic.ml primitive_types.ml int_types.ml repeated.ml enum.ml empty_message.ml
    message.ml oneof.ml map.ml package.ml include.ml included.ml large.ml
    included2.ml included3_dash.ml service.ml recursive.ml protocol.ml name_clash.ml
    name_clash_mangle.ml proto2.ml packed.ml mangle_names.ml extensions.ml
@@ -43,8 +43,8 @@
  (deps
   (:plugin ../src/plugin/protoc_gen_ocaml.exe)
   (:proto
-    basic.proto primitive_types.proto int_types.proto repeated.proto
-    enum.proto message.proto oneof.proto map.proto package.proto large.proto
+    basic.proto primitive_types.proto int_types.proto repeated.proto enum.proto empty_message.proto
+    message.proto oneof.proto map.proto package.proto large.proto
     include.proto included.proto included2.proto included3-dash.proto service.proto
     recursive.proto protocol.proto name_clash.proto name_clash_mangle.proto
     proto2.proto packed.proto mangle_names.proto extensions.proto options.proto

--- a/test/dune
+++ b/test/dune
@@ -25,7 +25,9 @@
  (inline_tests)
  (modules :standard \ proto3_optional_test_opt)
  (preprocess
-  (pps ppx_expect ppx_deriving.show ppx_deriving.eq)))
+  (pps ppx_expect ppx_deriving.show ppx_deriving.eq))
+)
+
 
 
 (rule

--- a/test/dune
+++ b/test/dune
@@ -53,7 +53,7 @@
  (action
   (run protoc -I %{read-lines:google_include} -I .
        "--plugin=protoc-gen-ocaml=%{plugin}"
-       "--ocaml_out=open=Google_types;annot=[@@deriving show { with_path = false }, eq]:." %{proto})))
+       "--ocaml_out=open=Google_types;open=Test_runtime;annot=[@@deriving show { with_path = false }, eq]:." %{proto})))
 
 (rule
  (targets int_types_native.ml int_types_native_proto2.ml)
@@ -63,7 +63,7 @@
  (action
   (run protoc -I %{read-lines:google_include} -I .
        "--plugin=protoc-gen-ocaml=%{plugin}"
-       "--ocaml_out=open=Google_types;int32_as_int=false;int64_as_int=false;annot=[@@deriving show { with_path = false }, eq]:." %{proto})))
+       "--ocaml_out=open=Google_types;open=Test_runtime;int32_as_int=false;int64_as_int=false;annot=[@@deriving show { with_path = false }, eq]:." %{proto})))
 
 (rule
  (targets singleton_record.ml oneof2.ml)
@@ -73,7 +73,7 @@
  (action
   (run protoc -I %{read-lines:google_include} -I .
        "--plugin=protoc-gen-ocaml=%{plugin}"
-       "--ocaml_out=open=Google_types;annot=[@@deriving show { with_path = false }, eq]:." %{proto})))
+       "--ocaml_out=open=Google_types;open=Test_runtime;annot=[@@deriving show { with_path = false }, eq]:." %{proto})))
 
 (rule
  (enabled_if (<> %{read:config/support_proto3_optional.conf} ""))
@@ -86,4 +86,4 @@
   (run protoc -I %{read-lines:google_include} -I .
        "--experimental_allow_proto3_optional"
        "--plugin=protoc-gen-ocaml=%{plugin}"
-       "--ocaml_out=open=Google_types;annot=[@@deriving show { with_path = false }, eq]:." %{proto})))
+       "--ocaml_out=open=Google_types;open=Test_runtime;annot=[@@deriving show { with_path = false }, eq]:." %{proto})))

--- a/test/dune
+++ b/test/dune
@@ -36,7 +36,7 @@
 (rule
  (targets
    basic.ml primitive_types.ml int_types.ml repeated.ml enum.ml empty_message.ml
-   message.ml oneof.ml map.ml package.ml include.ml included.ml large.ml
+   message.ml oneof.ml merge.ml map.ml package.ml include.ml included.ml large.ml
    included2.ml included3_dash.ml service.ml recursive.ml protocol.ml name_clash.ml
    name_clash_mangle.ml proto2.ml packed.ml mangle_names.ml extensions.ml
    options.ml name_clash2.ml empty.ml service_rpc_clash.ml service_empty_package.ml)
@@ -44,7 +44,7 @@
   (:plugin ../src/plugin/protoc_gen_ocaml.exe)
   (:proto
     basic.proto primitive_types.proto int_types.proto repeated.proto enum.proto empty_message.proto
-    message.proto oneof.proto map.proto package.proto large.proto
+    message.proto oneof.proto merge.proto map.proto package.proto large.proto
     include.proto included.proto included2.proto included3-dash.proto service.proto
     recursive.proto protocol.proto name_clash.proto name_clash_mangle.proto
     proto2.proto packed.proto mangle_names.proto extensions.proto options.proto

--- a/test/empty_message.proto
+++ b/test/empty_message.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+message Empty { }

--- a/test/empty_message_test.ml
+++ b/test/empty_message_test.ml
@@ -1,0 +1,6 @@
+let%expect_test _ =
+  let module T = Empty_message.Empty in
+  let validate = T.make () in
+  let t = () in
+  Test_lib.test_encode (module T) ~validate t;
+  [%expect {| |}]

--- a/test/enum_test.ml
+++ b/test/enum_test.ml
@@ -14,13 +14,10 @@ let%expect_test _ =
 let%expect_test _ =
   let module T = Enum.Aliasing in
   let t = T.Enum.Z in
-  Test_lib.test_encode (module T) t;
-  (* We do expect the enum to be deserialized as Y. *)
+  (* Due to aliasing, we expect this to be deserialized as 'Y'. *)
+  Test_lib.test_encode (module T) ~expect:T.Enum.Y t;
   [%expect {|
-    e: Y
-
-    Expect  :Z
-    Observed:Y |}]
+    e: Y |}]
 
 let%expect_test _ =
   let module T = Enum.Negative in

--- a/test/extensions.proto
+++ b/test/extensions.proto
@@ -26,3 +26,11 @@ extend Foo {
     optional uint32 a = 131;
     optional uint32 b = 132 [default = 13];
 }
+
+message Bar {
+    extensions 100 to 199;
+}
+
+extend Bar {
+    optional uint32 z = 131;
+}

--- a/test/extensions_test.ml
+++ b/test/extensions_test.ml
@@ -16,6 +16,7 @@ let%expect_test _ =
   let foo = Extensions.Foo.{ bar = Some 5; extensions' = Ocaml_protoc_plugin.Extensions.default } in
   let foo = Extensions.Baz'.set foo (Some 8) in
   let foo = Extensions.Baz'.set foo (Some 7) in
+  Test_lib.test_encode ~protoc:false (module Extensions.Foo) foo;
   let baz = Extensions.Baz'.get foo in
   print_endline ([%show: Extensions.Foo.t] foo);
   print_endline ([%show: Extensions.Baz.t Ocaml_protoc_plugin.Result.t] baz);
@@ -34,6 +35,8 @@ let%expect_test _ =
   let foo = Extensions.Baz'.set foo (Some 0) in
   let foo = Extensions.B2.set foo ([6;7;8]) in
   let foo = Extensions.B2.set foo ([]) in
+  Test_lib.test_encode ~protoc:false (module Extensions.Foo) foo;
+
   print_endline ([%show: Extensions.Foo.t] foo);
   ();
   [%expect {|
@@ -42,6 +45,8 @@ let%expect_test _ =
 let%expect_test _ =
   let foo = Extensions.Foo.{ bar = Some 5; extensions' = Ocaml_protoc_plugin.Extensions.default } in
   let foo = Extensions.Baz'.set foo (Some 7) in
+  Test_lib.test_encode ~protoc:false (module Extensions.Foo) foo;
+
   let foo' =
     Extensions.Foo.to_proto foo
     |> Ocaml_protoc_plugin.Writer.contents
@@ -61,6 +66,7 @@ let%expect_test _ =
 let%expect_test _ =
   let v = [6;7;8;9] in
   let foo = Extensions.Foo.{ bar = Some 5; extensions' = Ocaml_protoc_plugin.Extensions.default } in
+  Test_lib.test_encode ~protoc:false (module Extensions.Foo) foo;
   let foo = Extensions.R_baz.set foo v in
   let foo' =
     Extensions.Foo.to_proto foo
@@ -100,6 +106,7 @@ let%expect_test _ =
 
   let foo = Extensions.B.set foo 0 in
   Printf.printf "Set B = 0: %d\n" (Extensions.B.get foo |> Ocaml_protoc_plugin.Result.get ~msg:"No Value");
+  Test_lib.test_encode ~protoc:false (module Extensions.Foo) foo;
   print_endline ([%show: Extensions.Foo.t] foo);
   ();
   [%expect {|

--- a/test/extensions_test.ml
+++ b/test/extensions_test.ml
@@ -25,7 +25,7 @@ let%expect_test _ =
   in
   ();
   [%expect {|
-    { extensions' = (128, (Field.Varint 7L)); bar = (Some 5) }
+    { bar = (Some 5); extensions' = (128, (Field.Varint 7L)) }
     Ok (Some 7) |}]
 
 let%expect_test _ =
@@ -37,7 +37,7 @@ let%expect_test _ =
   print_endline ([%show: Extensions.Foo.t] foo);
   ();
   [%expect {|
-    { extensions' = (128, (Field.Varint 0L)); bar = (Some 5) } |}]
+    { bar = (Some 5); extensions' = (128, (Field.Varint 0L)) } |}]
 
 let%expect_test _ =
   let foo = Extensions.Foo.{ bar = Some 5; extensions' = Ocaml_protoc_plugin.Extensions.default } in
@@ -103,14 +103,14 @@ let%expect_test _ =
   print_endline ([%show: Extensions.Foo.t] foo);
   ();
   [%expect {|
-    { extensions' = ; bar = (Some 5) }
+    { bar = (Some 5); extensions' =  }
     Set A = Some 7
-    { extensions' = (131, (Field.Varint 7L)); bar = (Some 5) }
+    { bar = (Some 5); extensions' = (131, (Field.Varint 7L)) }
     Set A = None
-    { extensions' = ; bar = (Some 5) }
+    { bar = (Some 5); extensions' =  }
     Set B = 15: 15
-    { extensions' = (132, (Field.Varint 15L)); bar = (Some 5) }
+    { bar = (Some 5); extensions' = (132, (Field.Varint 15L)) }
     Set B = 13: 13
-    { extensions' = ; bar = (Some 5) }
+    { bar = (Some 5); extensions' =  }
     Set B = 0: 0
-    { extensions' = (132, (Field.Varint 0L)); bar = (Some 5) } |}]
+    { bar = (Some 5); extensions' = (132, (Field.Varint 0L)) } |}]

--- a/test/large_test.ml
+++ b/test/large_test.ml
@@ -1,19 +1,8 @@
 open Large
-open Ocaml_protoc_plugin
 
 let%expect_test "Test very large message type" =
   let large = Large.make ~x7:7 () in
-  let writer = Large.to_proto large in
-  let contents = Writer.contents writer in
-  Printf.printf "Size of large message: %d\n" (String.length contents);
-  let reader = Reader.create contents in
-  let large' = Large.from_proto_exn reader in
-  Printf.printf "Serialization works: %b\n" (large = large');
-  Printf.printf "x7: %d = %d\n" large.x7 large'.x7;
-  Printf.printf "x5: %d = %d\n" large.x5 large'.x5;
+  Test_lib.test_encode (module Large) large;
   ();
   [%expect {|
-    Size of large message: 2
-    Serialization works: true
-    x7: 7 = 7
-    x5: 0 = 0 |}]
+    x7: 7 |}]

--- a/test/merge.proto
+++ b/test/merge.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package merge;
+
+message T {
+  int64 a = 1;
+  repeated int64 b = 2;
+  repeated string c = 3;
+  T d = 4;
+
+  oneof o {
+    int64 i = 12;
+    T k = 11;
+    string j = 10;
+  };
+}

--- a/test/merge_test.ml
+++ b/test/merge_test.ml
@@ -1,0 +1,144 @@
+open !StdLabels
+open Merge.Merge
+
+let test_merge (type t) (module T: Test_lib.T with type t = t) (init : t) (ts: t list) =
+  let open Ocaml_protoc_plugin in
+
+  let writer = Writer.init () in
+  let expect =
+    List.fold_left ~init ~f:(fun acc t ->
+      Printf.printf "%s\n" (T.show t);
+      let _ = T.to_proto' writer t in
+      T.merge acc t
+    ) ts
+  in
+  let merged = T.from_proto (Reader.create (Writer.contents writer)) |> Result.get ~msg:"Unable to decode merged messages" in
+  Printf.printf "Merged: %s\n" (T.show merged);
+  let () = match merged = expect with
+    | false ->
+      Printf.printf "Merge results not equal\n";
+      Printf.printf "Expected: %s\n" (T.show expect);
+    | true -> ()
+  in
+  ()
+
+let%expect_test "merge int" =
+  (* Create a set of tests, each expanding on the previous *)
+  (* And we should extend test_encode to verify merge for all message types *)
+  (* But in this test we want to explicitly test it *)
+  (* Also for merging multiple messages *)
+
+  let t1 = T.make ~a:5 () in
+  let t2 = T.make ~a:7 () in
+  test_merge (module T) (T.make ()) [t1; t2];
+  [%expect {|
+    { a = 5; b = []; c = []; d = None; o = `not_set }
+    { a = 7; b = []; c = []; d = None; o = `not_set }
+    Merged: { a = 7; b = []; c = []; d = None; o = `not_set } |}]
+
+let%expect_test "merge int" =
+  (* Create a set of tests, each expanding on the previous *)
+  (* And we should extend test_encode to verify merge for all message types *)
+  (* But in this test we want to explicitly test it *)
+  (* Also for merging multiple messages *)
+
+  let t1 = T.make ~b:[1;2;3] () in
+  let t2 = T.make ~b:[4;5;6] () in
+  let t3 = T.make ~b:[7;8;9] () in
+  test_merge (module T) (T.make ()) [t1; t2; t3];
+  [%expect {|
+    { a = 0; b = [1; 2; 3]; c = []; d = None; o = `not_set }
+    { a = 0; b = [4; 5; 6]; c = []; d = None; o = `not_set }
+    { a = 0; b = [7; 8; 9]; c = []; d = None; o = `not_set }
+    Merged: { a = 0; b = [1; 2; 3; 4; 5; 6; 7; 8; 9]; c = []; d = None; o = `not_set } |}]
+
+let%expect_test "merge string" =
+  (* Create a set of tests, each expanding on the previous *)
+  (* And we should extend test_encode to verify merge for all message types *)
+  (* But in this test we want to explicitly test it *)
+  (* Also for merging multiple messages *)
+
+  let t1 = T.make ~c:["1";"2";"3"] () in
+  let t2 = T.make ~c:["4";"5";"6"] () in
+  let t3 = T.make ~c:["7";"8";"9"] () in
+  test_merge (module T) (T.make ()) [t1; t2; t3];
+  [%expect {|
+    { a = 0; b = []; c = ["1"; "2"; "3"]; d = None; o = `not_set }
+    { a = 0; b = []; c = ["4"; "5"; "6"]; d = None; o = `not_set }
+    { a = 0; b = []; c = ["7"; "8"; "9"]; d = None; o = `not_set }
+    Merged: { a = 0; b = []; c = ["1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9"]; d = None;
+      o = `not_set } |}]
+
+let%expect_test "merge message" =
+  (* Create a set of tests, each expanding on the previous *)
+  (* And we should extend test_encode to verify merge for all message types *)
+  (* But in this test we want to explicitly test it *)
+  (* Also for merging multiple messages *)
+
+  let t11 = T.make ~a:1 ~b:[1;2;3] () in
+  let t12 = T.make ~a:2 ~b:[4;5;6] () in
+  let t13 = T.make ~a:3 ~b:[7;8;9] () in
+  let t1 = T.make ~a:6 ~d:t11 () in
+  let t2 = T.make ~a:7 ~d:t12 () in
+  let t3 = T.make ~a:8 ~d:t13 () in
+
+  test_merge (module T) (T.make ()) [t1; t2; t3];
+  [%expect {|
+    { a = 6; b = []; c = [];
+      d = (Some { a = 1; b = [1; 2; 3]; c = []; d = None; o = `not_set });
+      o = `not_set }
+    { a = 7; b = []; c = [];
+      d = (Some { a = 2; b = [4; 5; 6]; c = []; d = None; o = `not_set });
+      o = `not_set }
+    { a = 8; b = []; c = [];
+      d = (Some { a = 3; b = [7; 8; 9]; c = []; d = None; o = `not_set });
+      o = `not_set }
+    Merged: { a = 8; b = []; c = [];
+      d =
+      (Some { a = 3; b = [1; 2; 3; 4; 5; 6; 7; 8; 9]; c = []; d = None;
+              o = `not_set });
+      o = `not_set } |}]
+
+let%expect_test "merge last oneof" =
+  (* Create a set of tests, each expanding on the previous *)
+  (* And we should extend test_encode to verify merge for all message types *)
+  (* But in this test we want to explicitly test it *)
+  (* Also for merging multiple messages *)
+
+  let t1 = T.make ~o:(`I 5) () in
+  let t2 = T.make ~o:(`J "7") () in
+  test_merge (module T) (T.make ()) [t1; t2];
+  [%expect {|
+    { a = 0; b = []; c = []; d = None; o = `I (5) }
+    { a = 0; b = []; c = []; d = None; o = `J ("7") }
+    Merged: { a = 0; b = []; c = []; d = None; o = `J ("7") } |}]
+
+let%expect_test "merge message oneof" =
+  (* Create a set of tests, each expanding on the previous *)
+  (* And we should extend test_encode to verify merge for all message types *)
+  (* But in this test we want to explicitly test it *)
+  (* Also for merging multiple messages *)
+
+  let t11 = T.make ~a:1 ~b:[1;2;3] () in
+  let t12 = T.make ~a:2 ~b:[4;5;6] () in
+  let t13 = T.make ~a:3 ~b:[7;8;9] () in
+
+  let t1 = T.make ~o:(`K t11) () in
+  let t2 = T.make ~o:(`K t12) () in
+  let t3 = T.make ~o:(`K t13) () in
+  test_merge (module T) (T.make ()) [t1; t2; t3];
+  [%expect {|
+    { a = 0; b = []; c = []; d = None;
+      o = `K ({ a = 1; b = [1; 2; 3]; c = []; d = None; o = `not_set }) }
+    { a = 0; b = []; c = []; d = None;
+      o = `K ({ a = 2; b = [4; 5; 6]; c = []; d = None; o = `not_set }) }
+    { a = 0; b = []; c = []; d = None;
+      o = `K ({ a = 3; b = [7; 8; 9]; c = []; d = None; o = `not_set }) }
+    Merged: { a = 0; b = []; c = []; d = None;
+      o = `K ({ a = 3; b = [7; 8; 9]; c = []; d = None; o = `not_set }) }
+    Merge results not equal
+    Expected: { a = 0; b = []; c = []; d = None;
+      o =
+      `K ({ a = 3; b = [1; 2; 3; 4; 5; 6; 7; 8; 9]; c = []; d = None;
+            o = `not_set })
+      } |}]

--- a/test/merge_test.ml
+++ b/test/merge_test.ml
@@ -3,7 +3,6 @@ open Merge.Merge
 
 let test_merge (type t) (module T: Test_lib.T with type t = t) (init : t) (ts: t list) =
   let open Ocaml_protoc_plugin in
-
   let writer = Writer.init () in
   let expect =
     List.fold_left ~init ~f:(fun acc t ->

--- a/test/oneof.proto
+++ b/test/oneof.proto
@@ -52,7 +52,7 @@ message Test5 {
 }
 
 message Test6 {
-  optional int64 i = 1;
+  int64 i = 1;
   oneof a {
     int64 a1 = 10;
     int64 a2 = 21;

--- a/test/oneof.proto
+++ b/test/oneof.proto
@@ -52,11 +52,17 @@ message Test5 {
 }
 
 message Test6 {
-  int64 i = 1;
+  optional int64 i = 1;
   oneof a {
     int64 a1 = 10;
     int64 a2 = 21;
   };
   int64 j = 20;
-  oneof b { int64 f = 30; };
+  oneof b {
+    int64 f = 30;
+    int64 ff = 31;
+  };
+  oneof c {
+    Test6 g = 40;
+  };
 }

--- a/test/primitive_types_test.ml
+++ b/test/primitive_types_test.ml
@@ -42,26 +42,8 @@ let%expect_test _ =
 
 let%expect_test _ =
   let module T = Primitive_types.Types in
-  let t =
-    T.
-      {
-        int64 = 0;
-        sint64 = 0;
-        uint64 = 0;
-        int32 = 0;
-        sint32 = 0;
-        uint32 = 0;
-        double = 0.0;
-        float = 0.0;
-        fixed64 = 0L;
-        fixed32 = 0l;
-        sfixed64 = 0L;
-        sfixed32 = 0l;
-        bool = false;
-        string = "";
-        bytes = Bytes.of_string "";
-      }
-  in
+  let t = T.make () in
+  Test_lib.test_encode (module T) t;
   let bin = T.to_proto t in
   Printf.printf "Size: %d%!" (Ocaml_protoc_plugin.Writer.contents bin |> String.length);
   [%expect {| Size: 0 |}]

--- a/test/proto2.proto
+++ b/test/proto2.proto
@@ -75,9 +75,29 @@ message MessageDefaults {
   };
 }
 
+// Default on oneofs makes really no sense
 message Oneof_default {
   oneof a {
     int64 i = 1 [default = 5];
     int64 j = 2 [default = 7];
   };
+}
+
+message NameClash {
+  message M1 { required int64 t = 1; };
+  message M2 { required int64 t = 1; };
+  message M3 { required int64 t = 1; };
+  message M4 { required int64 t = 1; };
+  message M5 { required int64 t = 1; };
+  required M1 t = 1;
+  required M2 T = 2;
+  required M3 _t = 3;
+  required M3 _T = 4;
+  required M4 T_ = 5;
+
+  oneof oneof {
+    int64 not_set = 10;
+    int64 Not_set = 11;
+    int64 Not_Set = 12;
+  }
 }

--- a/test/proto2.proto
+++ b/test/proto2.proto
@@ -9,6 +9,7 @@ message A {
 message Message {
   message Required {
     optional uint64 a = 1;
+    optional uint64 b = 2;
   }
   enum E {
     A = 0;

--- a/test/proto2.proto
+++ b/test/proto2.proto
@@ -70,4 +70,14 @@ message MessageDefaults {
   optional float    oc = 22 [default = -27];
   optional double   od = 23 [default = -27];
   optional bool     oe = 24 [default = true];
+  oneof of {
+    int64 og = 1 [default = 5];
+  };
+}
+
+message Oneof_default {
+  oneof a {
+    int64 i = 1 [default = 5];
+    int64 j = 2 [default = 7];
+  };
 }

--- a/test/proto2_test.ml
+++ b/test/proto2_test.ml
@@ -26,7 +26,7 @@ let%expect_test "Required fields must be in the message" =
     | Ok t -> print_endline (T.show t)
     | Error e  -> Printf.printf "Decode failure: %s\n" (Ocaml_protoc_plugin.Result.show_error e)
   in ();
-  [%expect {| Decode failure: `Required_field_missing |}]
+  [%expect {| Decode failure: `Required_field_missing ((2, Int32_int)) |}]
 
 let%expect_test "Only tramitting the required field" =
   let module T = Proto2.Message1_ in

--- a/test/proto2_test.ml
+++ b/test/proto2_test.ml
@@ -1,7 +1,12 @@
 open Proto2
+
 let%expect_test _ =
   let module T = Proto2.Message in
-  let t = T.{enum = Some E.B; i = 0; j = 5; required = Some 7; k = Some 5 } in
+  (* Verify signature that required messages are mapped as mandatory arguments *)
+  let make: ?enum:T.E.t -> ?i:int -> j:int -> required:T.Required.t -> ?k:int -> unit -> T.t = T.make in
+  let t' = make ~enum:T.E.B ~i:0 ~j:5 ~required:(T.Required.make ~a:7 ()) ~k:5 () in
+  let t = T.{enum = Some E.B; i = 0; j = 5; required = T.Required.make ~a:7 (); k = Some 5 } in
+  if (not (T.equal t t')) then Printf.eprintf "Error: Type does not match";
   Test_lib.test_encode (module T) t;
   [%expect {|
     enum: B

--- a/test/proto2_test.ml
+++ b/test/proto2_test.ml
@@ -51,6 +51,12 @@ let%expect_test "Default created messages should not set any fields" =
   in ();
   [%expect {|
     Size of message: 0
-    { o0 = "default string"; o1 = "default bytes"; o2 = 27; o3 = 27; o4 = -27;
-      o5 = -27; o6 = -27; o7 = -27; o8 = 27l; o9 = 27L; oa = -27l; ob = -27L;
-      oc = -27.; od = -27.; oe = true } |}]
+    { of' = `not_set; o0 = "default string"; o1 = "default bytes"; o2 = 27;
+      o3 = 27; o4 = -27; o5 = -27; o6 = -27; o7 = -27; o8 = 27l; o9 = 27L;
+      oa = -27l; ob = -27L; oc = -27.; od = -27.; oe = true } |}]
+
+let%expect_test "Default values in oneofs are ignored" =
+  let module T = Proto2.Oneof_default in
+  let t = T.make ~a:(`I 5) () in
+  Test_lib.test_encode (module T) t;
+  [%expect {| i: 5 |}]

--- a/test/test_lib.ml
+++ b/test/test_lib.ml
@@ -1,10 +1,13 @@
 open StdLabels
+open Ocaml_protoc_plugin
 
 module type T = sig
   type t [@@deriving show, eq]
-  val to_proto : t -> Ocaml_protoc_plugin.Writer.t
-  val from_proto : Ocaml_protoc_plugin.Reader.t -> t Ocaml_protoc_plugin.Result.t
+  val to_proto' : Writer.t -> t -> Writer.t
+  val to_proto : t -> Writer.t
+  val from_proto : Reader.t -> t Result.t
   val name' : unit -> string
+  val merge: t -> t -> t
 end
 
 let hexlify data =
@@ -41,14 +44,36 @@ let dump_protoc ?(protoc_args=[]) name data =
   | 0 -> ()
   | n -> Printf.printf "'protoc' exited with status code: %d\n" n
 
+let test_merge (type t) (module M : T with type t = t) (t: t) =
+  let iterations = [1;2;3;4] in
+  let writer = Writer.init () in
+  let _ =
+    List.fold_left ~init:(writer, t) ~f:(fun (writer, expect) i ->
+      let writer = M.to_proto' writer t in
+      let contents = Writer.contents writer |> Reader.create in
+      let () =
+        match M.from_proto contents with
+        | Error err ->  Printf.printf "Error decoding after %d iterations: %s\n" i (Result.show_error err)
+        | Ok observed when M.equal expect observed -> ()
+        | Ok observed ->
+          Printf.printf "Wrong value after %d iterations\nExpect: %s\nObserved:%s\n" i ([%show: M.t] expect) ([%show: M.t] observed)
+      in
+      (writer, M.merge expect t)
+    ) iterations
+  in
+  ()
+
+
 
 (** Create a common function for testing. *)
-let test_encode (type t) ?dump ?(protoc=true) ?protoc_args (module M : T with type t = t) ?(validate : t option) (expect : t) =
+let test_encode (type t) ?dump ?(protoc=true) ?protoc_args (module M : T with type t = t) ?(validate : t option) ?(expect : t option) (t : t) =
+  let expect = Option.value ~default:t expect in
   let () = match validate with
     | Some v when v <> expect -> Printf.printf "Validate match failed\n"
     | _ -> ()
   in
-  let data = M.to_proto expect |> Ocaml_protoc_plugin.Writer.contents in
+  let data = M.to_proto expect |> Writer.contents in
+
   let () =
     match dump with
     | Some _ -> hexlify data
@@ -58,11 +83,24 @@ let test_encode (type t) ?dump ?(protoc=true) ?protoc_args (module M : T with ty
     | true -> dump_protoc ?protoc_args (M.name' ()) data
     | false -> ()
   in
-  (* Decode the message *)
-  let in_data = Ocaml_protoc_plugin.Reader.create data in
-  match M.from_proto in_data with
-  | Ok observed when M.equal expect observed -> ()
-  | Ok observed ->
-    Printf.printf "\nExpect  :%s\nObserved:%s\n" ([%show: M.t] expect) ([%show: M.t] observed)
-  | Error err ->
-    Printf.printf "\nDecode failed: %s \n" (Ocaml_protoc_plugin.Result.show_error err)
+  let in_data_unordered =
+    let writer = Writer.init () in
+    Writer.write_field writer (1 lsl 29 - 1) (Field.varint_unboxed 5);
+    let _ = M.to_proto' writer expect in
+    Reader.create (Writer.contents writer)
+  in
+  let in_data = Reader.create data in
+  match (M.from_proto in_data, M.from_proto in_data_unordered) with
+  | Ok observed, Ok observed_unordered -> begin
+      match M.equal expect observed, M.equal expect observed_unordered with
+      | true, true ->
+        test_merge (module M) expect
+      | false, _ ->
+        Printf.printf "\nExpect: %s\nObserved:%s\n" ([%show: M.t] expect) ([%show: M.t] observed)
+      | _, false ->
+        Printf.printf "\nExpect(unordered):%s\nObserved:%s\n" ([%show: M.t] expect) ([%show: M.t] observed_unordered)
+    end
+  | Error err, _ ->
+    Printf.printf "\nDecode failed: %s \n" (Result.show_error err)
+  | _, Error err ->
+    Printf.printf "\nDecode unordered failed: %s \n" (Result.show_error err)

--- a/test/test_lib.ml
+++ b/test/test_lib.ml
@@ -90,6 +90,9 @@ let test_encode (type t) ?dump ?(protoc=true) ?protoc_args (module M : T with ty
     | _ -> ()
   in
   let data = M.to_proto expect |> Writer.contents in
+  let data_speed = M.to_proto' (Writer.init ~mode:Speed ()) expect |> Writer.contents in
+  let data_space = M.to_proto' (Writer.init ~mode:Space ()) expect |> Writer.contents in
+  let data_balanced = M.to_proto' (Writer.init ~mode:Balanced ()) expect |> Writer.contents in
 
   let () =
     match dump with
@@ -100,6 +103,10 @@ let test_encode (type t) ?dump ?(protoc=true) ?protoc_args (module M : T with ty
     | true -> dump_protoc ?protoc_args (M.name' ()) data
     | false -> ()
   in
+
+  test_decode (module M) Test_runtime.Standard expect data_space;
+  test_decode (module M) Test_runtime.Standard expect data_speed;
+  test_decode (module M) Test_runtime.Standard expect data_balanced;
   test_decode (module M) Test_runtime.Standard expect data;
   test_decode (module M) Test_runtime.Fast expect data;
   test_decode (module M) Test_runtime.Full expect data;

--- a/test/test_runtime.ml
+++ b/test/test_runtime.ml
@@ -1,0 +1,19 @@
+(** Module to force specific deserialization strategies during tests
+    though dependency injection *)
+
+type strategy = Fast | Full | Standard [@@deriving show]
+let strategy = ref Standard
+let set_stragegy s = strategy := s
+
+module Runtime' = struct
+  include Ocaml_protoc_plugin.Runtime.Runtime'
+  module Deserialize : module type of Deserialize = struct
+    include Deserialize
+    let deserialize spec constr reader =
+      match !strategy with
+      | Fast ->
+        deserialize_fast spec constr reader
+      | Full -> deserialize_full spec constr reader
+      | Standard -> deserialize spec constr reader
+  end
+end


### PR DESCRIPTION
This pull request includes a series of changes primarily focused on improving the benchmarking process and modifying the deserialization process in the OCaml Protoc Plugin. The main changes include adding a new test function for integer tests, increasing the benchmark quota, adding a new `empty.proto` file, and making significant changes to the `deserialize.ml` and `deserialize.mli` files.

Benchmarking improvements:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L74-R74): Modified the `bench` command to include a `--profile=bench` option, enhancing the benchmarking process.
* [`bench/bench.ml`](diffhunk://#diff-27f0ee83ca8d56480dc38863cf1eba96171396ee92d0e5ae25d35c914085e7dfR81-R100): Added a new function `make_int_tests` for integer tests and increased the benchmark quota from 1.0 to 5.0 seconds. Also, added a `make_tests` call for the `Protoc.Empty` module. [[1]](diffhunk://#diff-27f0ee83ca8d56480dc38863cf1eba96171396ee92d0e5ae25d35c914085e7dfR81-R100) [[2]](diffhunk://#diff-27f0ee83ca8d56480dc38863cf1eba96171396ee92d0e5ae25d35c914085e7dfL135-R155) [[3]](diffhunk://#diff-27f0ee83ca8d56480dc38863cf1eba96171396ee92d0e5ae25d35c914085e7dfL167-R203)

Additions to the codebase:

* [`bench/empty.proto`](diffhunk://#diff-ba167a50b9df1f6fb0cf33b1b2fd30f8f7154c0848d090ef5fa038559b031b77R1-R4): Added a new `empty.proto` file.
* `bench/plugin/dune` and `bench/protoc/dune`: Modified to include `empty.ml` in the targets and `../empty.proto` in the dependencies. [[1]](diffhunk://#diff-7e39ccda17e02435b35858a123f75f85108dddc4d6e0ea988932f9fd4fa8c5c5L3-R9) [[2]](diffhunk://#diff-dd0e47cf44eed991d6ae45a40f96c306705cb3dfbc4ed72bfa490eda98cdcc40L3-R11)
* [`dune-workspace`](diffhunk://#diff-97371917a4c1d57f3a1333620305f405ca6083939d493dd06450af3894b20c27R1-R3): Added new `ocamlopt_flags` for the `bench` environment.

Changes to the deserialization process:

* `src/ocaml_protoc_plugin/deserialize.ml` and `src/ocaml_protoc_plugin/deserialize.mli`: Made significant changes to the deserialization process, including modifying the `value` function, adding new functions like `extension_ranges`, `deserialize_fast`, and `deserialize_full`, and modifying the `deserialize` function. These changes aim to improve the efficiency and flexibility of the deserialization process. [[1]](diffhunk://#diff-d5e55ef45b77614485cbbf1c9643f04ee9c05e7527e460077f114a1f961d2e23L8-R31) [[2]](diffhunk://#diff-d5e55ef45b77614485cbbf1c9643f04ee9c05e7527e460077f114a1f961d2e23L85-R99) [[3]](diffhunk://#diff-d5e55ef45b77614485cbbf1c9643f04ee9c05e7527e460077f114a1f961d2e23R109-R122) [[4]](diffhunk://#diff-d5e55ef45b77614485cbbf1c9643f04ee9c05e7527e460077f114a1f961d2e23L161-R181) [[5]](diffhunk://#diff-d5e55ef45b77614485cbbf1c9643f04ee9c05e7527e460077f114a1f961d2e23R190-R205) [[6]](diffhunk://#diff-d5e55ef45b77614485cbbf1c9643f04ee9c05e7527e460077f114a1f961d2e23L232-R290) [[7]](diffhunk://#diff-949d3bf4b21b59a048b9ba214e7b73f9415878bcdfc4f29b63adf305efe94d10L3-R15)